### PR TITLE
Cut

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -27,6 +27,7 @@ lib/Chronicle/Plugin/Snippets/RecentPosts.pm
 lib/Chronicle/Plugin/Snippets/RecentTags.pm
 lib/Chronicle/Plugin/Textile.pm
 lib/Chronicle/Plugin/Tidy.pm
+lib/Chronicle/Plugin/TruncatedBody.pm
 lib/Chronicle/Plugin/YouTube.pm
 LICENSE
 Makefile.PL

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -633,7 +633,9 @@ sub insertPost
     }
     close($handle);
 
-
+    # initicate the truncated body.
+    $meta{ 'truncatedbody' } = '';
+  
     #
     #  Generate the link from the title of the post.
     #
@@ -729,7 +731,7 @@ sub insertPost
     #  Now insert
     #
     my $post_add = $dbh->prepare(
-        "INSERT INTO blog (file,date,title,link,mtime,body) VALUES( ?,?,?,?,?,?)"
+        "INSERT INTO blog (file,date,title,link,mtime,body,truncatedbody) VALUES( ?,?,?,?,?,?,?)"
       ) or
       die "Failed to prepare";
 
@@ -737,7 +739,8 @@ sub insertPost
                         $meta{ 'date' },
                         $meta{ 'title' },
                         $meta{ 'link' },
-                        $mtime, $meta{ 'body' } ) or
+                        $mtime, $meta{ 'body' },
+                        $meta{ 'truncatedbody' } ) or
       die "Failed to insert:" . $dbh->errstr();
 
     my $blog_id = $dbh->func('last_insert_rowid');
@@ -812,7 +815,7 @@ sub getDatabase
     {
 
         $dbh->do(
-            "CREATE TABLE blog (id INTEGER PRIMARY KEY, file, date,title, link,mtime, body );"
+            "CREATE TABLE blog (id INTEGER PRIMARY KEY, file, date,title, link,mtime, body, truncatedbody );"
         );
         $dbh->do("CREATE TABLE tags (id INTEGER PRIMARY KEY, name, blog_id );");
 

--- a/lib/Chronicle/Plugin/Markdown.pm
+++ b/lib/Chronicle/Plugin/Markdown.pm
@@ -54,8 +54,8 @@ sub on_insert
     #
     #  The post data and input format
     #
-    my $data   = $args{ 'data' };
-    my $format = $data->{ 'format' };
+    my $data   = $args{'data'};
+    my $format = $data->{'format'};
 
     if ( $format && ( $format =~ /^markdown$/i ) )
     {
@@ -75,11 +75,14 @@ If you're on a Debian GNU/Linux system you can fix this via:
 EOF
             exit(1);
         }
-        if ($data->{ 'truncatedbody' })
+
+        foreach my $key (qw! truncatedbody body !)
         {
-        $data->{ 'truncatedbody' }  = Text::Markdown::markdown( $data->{ 'truncatedbody' } );
+            $data->{$key} = Text::Markdown::markdown( $data->{$key} )
+                if ( $data->{$key} );
         }
-        $data->{ 'body' } = Text::Markdown::markdown( $data->{ 'body' } );
+
+
 
     }
     return ($data);

--- a/lib/Chronicle/Plugin/Markdown.pm
+++ b/lib/Chronicle/Plugin/Markdown.pm
@@ -75,7 +75,10 @@ If you're on a Debian GNU/Linux system you can fix this via:
 EOF
             exit(1);
         }
-
+        if ($data->{ 'truncatedbody' })
+        {
+        $data->{ 'truncatedbody' }  = Text::Markdown::markdown( $data->{ 'truncatedbody' } );
+        }
         $data->{ 'body' } = Text::Markdown::markdown( $data->{ 'body' } );
 
     }

--- a/lib/Chronicle/Plugin/MultiMarkdown.pm
+++ b/lib/Chronicle/Plugin/MultiMarkdown.pm
@@ -75,7 +75,10 @@ If you're on a Debian GNU/Linux system you can fix this via:
 EOF
             exit(1);
         }
-
+        if ($data->{ 'truncatedbody' })
+        {
+        $data->{ 'truncatedbody' }  = Text::MultiMarkdown::markdown( $data->{ 'truncatedbody' } );
+        }
         $data->{ 'body' } = Text::MultiMarkdown::markdown( $data->{ 'body' } );
 
     }

--- a/lib/Chronicle/Plugin/MultiMarkdown.pm
+++ b/lib/Chronicle/Plugin/MultiMarkdown.pm
@@ -54,8 +54,8 @@ sub on_insert
     #
     #  The post data and input format
     #
-    my $data   = $args{ 'data' };
-    my $format = $data->{ 'format' };
+    my $data   = $args{'data'};
+    my $format = $data->{'format'};
 
     if ( $format && ( $format =~ /^multimarkdown$/i ) )
     {
@@ -75,11 +75,11 @@ If you're on a Debian GNU/Linux system you can fix this via:
 EOF
             exit(1);
         }
-        if ($data->{ 'truncatedbody' })
+        foreach my $key (qw! truncatedbody body !)
         {
-        $data->{ 'truncatedbody' }  = Text::MultiMarkdown::markdown( $data->{ 'truncatedbody' } );
+            $data->{$key} = Text::MultiMarkdown::markdown( $data->{$key} )
+                if ( $data->{$key} );
         }
-        $data->{ 'body' } = Text::MultiMarkdown::markdown( $data->{ 'body' } );
 
     }
     return ($data);

--- a/lib/Chronicle/Plugin/Textile.pm
+++ b/lib/Chronicle/Plugin/Textile.pm
@@ -80,6 +80,10 @@ EOF
         }
 
         my $textile = new Text::Textile;
+        if ($data->{ 'truncatedbody' })
+        {
+        $data->{ 'truncatedbody' }  = $textile->process( $data->{ 'truncatedbody' } );
+        }
         $data->{ 'body' } = $textile->process( $data->{ 'body' } );
     }
 

--- a/lib/Chronicle/Plugin/Textile.pm
+++ b/lib/Chronicle/Plugin/Textile.pm
@@ -55,8 +55,8 @@ sub on_insert
     #
     #  The post data and input-format
     #
-    my $data   = $args{ 'data' };
-    my $format = $data->{ 'format' };
+    my $data   = $args{'data'};
+    my $format = $data->{'format'};
 
     if ( $format && ( $format =~ /^textile$/i ) )
     {
@@ -80,11 +80,15 @@ EOF
         }
 
         my $textile = new Text::Textile;
-        if ($data->{ 'truncatedbody' })
+
+        foreach my $key (qw! truncatedbody body !)
         {
-        $data->{ 'truncatedbody' }  = $textile->process( $data->{ 'truncatedbody' } );
+            $data->{$key} = $textile->process( $data->{$key} )
+                if ( $data->{$key} );
         }
-        $data->{ 'body' } = $textile->process( $data->{ 'body' } );
+
+
+
     }
 
     return ($data);

--- a/lib/Chronicle/Plugin/TruncatedBody.pm
+++ b/lib/Chronicle/Plugin/TruncatedBody.pm
@@ -44,6 +44,12 @@ reader to the rest of the article.
 
 The body text is then cleaned by removing C<__CUT__>. 
 
+:B<NOTE> If there are multiple __CUT__'s within a file, only the first 
+correctly placed __CUT__ will be used.  Other __CUTS__ will be ignored
+and will remain within the body and or in the trunacted body in the case of a
+incorrectly placed __CUT__ prior to a correctly placed __CUT__.
+
+
 
 =cut
 

--- a/lib/Chronicle/Plugin/TruncatedBody.pm
+++ b/lib/Chronicle/Plugin/TruncatedBody.pm
@@ -46,7 +46,7 @@ The body text is then cleaned by removing C<__CUT__>.
 
 :B<NOTE> If there are multiple __CUT__'s within a file, only the first 
 correctly placed __CUT__ will be used.  Other __CUTS__ will be ignored
-and will remain within the body and or in the trunacted body in the case of a
+and will remain within the body and or in the truncated body in the case of a
 incorrectly placed __CUT__ prior to a correctly placed __CUT__.
 
 

--- a/lib/Chronicle/Plugin/TruncatedBody.pm
+++ b/lib/Chronicle/Plugin/TruncatedBody.pm
@@ -1,0 +1,99 @@
+
+=head1 NAME
+
+Chronicle::Plugin::TruncatedBody - Support for Truncating longer blog posts.
+
+=head1 DESCRIPTION
+
+The module allows you to truncate longer blog posts.
+
+To use this you need to add C<__CUT__> within the post body to 
+the start of its own separate line.
+
+=cut
+
+=head1 METHODS
+
+Now follows documentation on the available methods.
+
+=cut
+
+package Chronicle::Plugin::TruncatedBody;
+
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+our $VERSION = "5.0.9";
+
+
+=head2 on_insert
+
+The C<on_insert> method is automatically invoked when a new blog post
+must be inserted into the SQLite database, that might be because a post
+is new, or because it has been updated.
+
+The method is designed to return an updated blog-post structure,
+after performing any massaging required.  If the method returns undef
+then the post is not inserted.
+
+If the new entry has a C<__CUT__> on its own line, the text before the 
+cut is marked as part of the truncated body and a link pointing the 
+reader to the rest of the article.
+
+The body text is then cleaned by removing C<__CUT__>. 
+
+
+=cut
+
+sub on_insert
+{
+    my ( $self, %args ) = (@_);
+
+    #
+    #  The post data and input format
+    #
+    my $data = $args{'data'};
+    my $body = $data->{'body'};
+    my $link = $data->{'link'};
+    $link = '' unless $link;
+    if ( $body =~ /(.+)\n\_\_CUT\_\_/s )
+    {
+        # assign the text before the cut to cut and add a link to read more
+        $data->{'truncatedbody'} = $1 . "\n\n<a href='$link'>Read More</a>";
+
+        # remove the cut from the main body
+        $data->{'body'} =~ s/__CUT__//;
+    }
+    return ($data);
+}
+
+
+# The order is important as we need to run this before any formatting is
+# applied to the post
+sub _order
+{
+    1;
+}
+1;
+
+
+=head1 LICENSE
+
+This module is free software; you can redistribute it and/or modify it
+under the terms of either:
+
+a) the GNU General Public License as published by the Free Software
+Foundation; either version 2, or (at your option) any later version,
+or
+
+b) the Perl "Artistic License".
+
+=cut
+
+=head1 AUTHOR
+
+Stuart Skelton
+
+=cut

--- a/lib/Chronicle/Plugin/TruncatedBody.pm
+++ b/lib/Chronicle/Plugin/TruncatedBody.pm
@@ -58,13 +58,14 @@ sub on_insert
     my $body = $data->{'body'};
     my $link = $data->{'link'};
     $link = '' unless $link;
-    if ( $body =~ /(.+)\n\_\_CUT\_\_/s )
+    # we are only concerned with first correct cut
+    if ( $body =~ /^(.+?)\n^__CUT__/ms )
     {
         # assign the text before the cut to cut and add a link to read more
-        $data->{'truncatedbody'} = $1 . "\n\n<a href='$link'>Read More</a>";
+        $data->{'truncatedbody'} = $1 . "\n\n<a href=\"$link\">Read More</a>";
 
         # remove the cut from the main body
-        $data->{'body'} =~ s/__CUT__//;
+        $data->{'body'} =~ s/^(.+?)\n^__CUT__/$1/ms;
     }
     return ($data);
 }

--- a/t/test-truncatedbody.t
+++ b/t/test-truncatedbody.t
@@ -3,35 +3,163 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 12;
 
 #
 #  Load the module.
 #
-BEGIN {use_ok('Chronicle::Plugin::TruncatedBody');}
+BEGIN { use_ok('Chronicle::Plugin::TruncatedBody'); }
 require_ok('Chronicle::Plugin::TruncatedBody');
 
 
 #
 #  Create some data
 #
-my %data;
-$data{ 'body' } =
-  "Text before the cut
+
+
+#
+#  This tests the correct form of one __CUT__
+#
+
+my %correct_cut_data;
+$correct_cut_data{'body'} = "Text before the cut
 __CUT__
 
 text after the cut";
 
- 
- 
-    my $out =
-      Chronicle::Plugin::TruncatedBody::on_insert( undef, data => \%data );
 
-    is( $out->{ 'body' },"Text before the cut
+my $out = Chronicle::Plugin::TruncatedBody::on_insert( undef,
+                                                 data => \%correct_cut_data );
+
+is( $out->{body}, 'Text before the cut
+
+text after the cut', 'one cut body'
+);
+
+is( $out->{truncatedbody}, "Text before the cut
+
+<a href=\"\">Read More</a>", 'one cut truncatedbody'
+);
 
 
-text after the cut");
-    is( $out->{ 'truncatedbody' },"Text before the cut
+#
+#  This tests the incorrect form of one __CUT__
+#
 
-<a href=''>Read More</a>");
+my %incorrect_cut_data;
+$incorrect_cut_data{'body'} = "Text before the cut
+ __CUT__
+
+text after the cut";
+
+
+$out = Chronicle::Plugin::TruncatedBody::on_insert( undef,
+                                               data => \%incorrect_cut_data );
+
+is( $out->{body}, 'Text before the cut
+ __CUT__
+
+text after the cut', 'one incorrect cut body'
+);
+
+is( $out->{truncatedbody}, undef, 'one incorrect cut truncatedbody' );
+
+
+#
+#  This tests with two __CUT__'s with the both cut being correct
+#
+
+my %two_cut_data;
+$two_cut_data{'body'} = "Text before the cut
+__CUT__
+
+text inbetween the cuts
+
+__CUT__
+text after the cut";
+
+
+$out = Chronicle::Plugin::TruncatedBody::on_insert( undef,
+                                                    data => \%two_cut_data );
+
+is( $out->{body}, 'Text before the cut
+
+text inbetween the cuts
+
+__CUT__
+text after the cut', 'two cut body'
+);
+
+is( $out->{truncatedbody}, "Text before the cut
+
+<a href=\"\">Read More</a>", 'two cut truncatedbody'
+);
+
+
+#
+#  This tests with two __CUT__'s with the first cut being correct
+#
+
+my %two_cut_data_1;
+$two_cut_data_1{'body'} = "Text before the cut
+__CUT__
+
+text inbetween the cuts
+
+ __CUT__
+text after the cut";
+
+
+$out = Chronicle::Plugin::TruncatedBody::on_insert( undef,
+                                                   data => \%two_cut_data_1 );
+
+is( $out->{body}, 'Text before the cut
+
+text inbetween the cuts
+
+ __CUT__
+text after the cut', 'two cut body 1'
+);
+
+is( $out->{truncatedbody}, "Text before the cut
+
+<a href=\"\">Read More</a>", 'two cut truncatedbody 1'
+);
+
+#
+#  This tests with two __CUT__'s with the second cut being correct
+#
+
+my %two_cut_data_2;
+$two_cut_data_2{'body'} = "Text before the cut
+ __CUT__
+
+text inbetween the cuts
+
+__CUT__
+text after the cut";
+
+
+$out = Chronicle::Plugin::TruncatedBody::on_insert( undef,
+                                                   data => \%two_cut_data_2 );
+
+is( $out->{body}, 'Text before the cut
+ __CUT__
+
+text inbetween the cuts
+
+text after the cut', 'two cut body 2'
+);
+
+is( $out->{truncatedbody}, "Text before the cut
+ __CUT__
+
+text inbetween the cuts
+
+
+<a href=\"\">Read More</a>", 'two cut truncatedbody 2'
+);
+
+
+
 

--- a/t/test-truncatedbody.t
+++ b/t/test-truncatedbody.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl -I../lib/ -Ilib/
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+#
+#  Load the module.
+#
+BEGIN {use_ok('Chronicle::Plugin::TruncatedBody');}
+require_ok('Chronicle::Plugin::TruncatedBody');
+
+
+#
+#  Create some data
+#
+my %data;
+$data{ 'body' } =
+  "Text before the cut
+__CUT__
+
+text after the cut";
+
+ 
+ 
+    my $out =
+      Chronicle::Plugin::TruncatedBody::on_insert( undef, data => \%data );
+
+    is( $out->{ 'body' },"Text before the cut
+
+
+text after the cut");
+    is( $out->{ 'truncatedbody' },"Text before the cut
+
+<a href=''>Read More</a>");
+

--- a/themes/bs2/inc/truncated-blog-post.inc
+++ b/themes/bs2/inc/truncated-blog-post.inc
@@ -1,0 +1,15 @@
+<h2><a href="<!-- tmpl_var name='top' --><!-- tmpl_var name='link' escape='html' -->"><!-- tmpl_var name='title' --></a></h2>
+<!-- tmpl_if name='tags' -->
+   <h6>Tags: <!-- tmpl_loop name='tags' --><a href="<!-- tmpl_var name='top' -->tags/<!-- tmpl_var name='tag' escape='html' -->"><!-- tmpl_var name='tag' escape='html' --></a><!-- tmpl_if name="__last__" -->.<!-- tmpl_else -->, <!-- /tmpl_if --><!-- /tmpl_loop --></h6>
+<!-- /tmpl_if -->
+
+    <!-- tmpl_if name='truncatedbody' -->
+	<!-- tmpl_var name='truncatedbody' -->
+    <!-- tmpl_else -->
+    <!-- tmpl_var name='body' -->
+    <!-- /tmpl_if -->
+<p class="blog-list-detail">
+Posted on <!-- tmpl_var name='date' --><!-- tmpl_if name='time' --> at <!-- tmpl_var name='time' --><!-- /tmpl_if --> -
+  <!-- tmpl_if name='comment_count' --><a href="<!-- tmpl_var name='top' --><!-- tmpl_var name='link' escape='html' -->"><!-- tmpl_var name='comment_count' --> comment<!-- tmpl_if name='comment_plural' -->s<!-- /tmpl_if -->.</a> <!-- tmpl_else -->No comments <!-- /tmpl_if -->
+</p>
+

--- a/themes/bs2/index.tmpl
+++ b/themes/bs2/index.tmpl
@@ -49,7 +49,7 @@
         <div class="span9 middle">
 <!-- tmpl_if name='entries' -->
 <!-- tmpl_loop name='entries' -->
-  <!-- tmpl_include name='inc/blog-post.inc' -->
+  <!-- tmpl_include name='inc/truncated-blog-post.inc' -->
 <!-- /tmpl_loop -->
 <!-- /tmpl_if -->
         </div>


### PR DESCRIPTION
This is my attempt to implement the cut feature as described in #23 .

This is implemented by:

1. search for the __CUT__ in the body
2. put all the text prior to the cut into a truncatedbody variable
3. add a link so the user can go to that post to 'read more'
4. remove the __CUT__ from the main body post.
5. the Formatters format both the truncatedbody and body
6. the truncated body is stored in the database in the 'truncatedbody' field  for later retrieval. 
 

