### PR TITLE
Per post templating

### DIFF
--- a/bin/chronicle
+++ b/bin/chronicle
@@ -636,6 +636,10 @@ sub insertPost
     # initicate the truncated body.
     $meta{ 'truncatedbody' } = '';
 
+    # initicate the template and change if there is a template is supplied.
+    $meta{ 'template' } = "entry.tmpl";
+    $meta{ 'template' } = '' unless defined $meta{ 'template' };
+
     #
     #  Generate the link from the title of the post.
     #
@@ -731,7 +735,7 @@ sub insertPost
     #  Now insert
     #
     my $post_add = $dbh->prepare(
-        "INSERT INTO blog (file,date,title,link,mtime,body,truncatedbody) VALUES( ?,?,?,?,?,?,?)"
+        "INSERT INTO blog (file,date,title,link,mtime,body,truncatedbody,template) VALUES( ?,?,?,?,?,?,?,?)"
       ) or
       die "Failed to prepare";
 
@@ -741,7 +745,8 @@ sub insertPost
                         $meta{ 'link' },
                         $mtime,
                         $meta{ 'body' },
-                        $meta{ 'truncatedbody' }
+                        $meta{ 'truncatedbody' },
+                        $meta{ 'template' }
       ) or
       die "Failed to insert:" . $dbh->errstr();
 
@@ -817,7 +822,7 @@ sub getDatabase
     {
 
         $dbh->do(
-            "CREATE TABLE blog (id INTEGER PRIMARY KEY, file, date,title, link,mtime, body, truncatedbody );"
+            "CREATE TABLE blog (id INTEGER PRIMARY KEY, file, date,title, link,mtime, body, truncatedbody, template );"
         );
         $dbh->do("CREATE TABLE tags (id INTEGER PRIMARY KEY, name, blog_id );");
 

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -637,8 +637,7 @@ sub insertPost
     $meta{ 'truncatedbody' } = '';
 
     # initicate the template and change if there is a template is supplied.
-    $meta{ 'template' } = "entry.tmpl";
-    $meta{ 'template' } = '' unless defined $meta{ 'template' };
+    $meta{ 'template' } = "entry.tmpl" unless defined $meta{ 'template' };
 
     #
     #  Generate the link from the title of the post.

--- a/lib/Chronicle/Plugin/Generate/Pages.pm
+++ b/lib/Chronicle/Plugin/Generate/Pages.pm
@@ -155,8 +155,7 @@ sub on_generate
         $config->{ 'verbose' } &&
           print "Creating : $config->{'output'}/$entry->{'link'}\n";
 
-
-        my $c = Chronicle::load_template("entry.tmpl");
+        my $c = Chronicle::load_template( $entry->{ 'template' } );
         return unless ($c);
         $c->param( top => $config->{ 'top' } );
         $c->param($entry);


### PR DESCRIPTION
This allows for the user to specify a template on a post to post basis, where it always default back to entry.tmpl.

No error checking should be needed Chronicle::load_template has this covered