### PR TITLE
Allow for the user to choose the min and max sizes for their tag cloud

### DIFF
--- a/bin/chronicle
+++ b/bin/chronicle
@@ -356,6 +356,8 @@ $CONFIG{ 'verbose' }      = 0;
 $CONFIG{ 'top' }          = "/";
 $CONFIG{ 'exclude-plugins' } =
   "Chronicle::Plugin::Archived,Chronicle::Plugin::Verbose";
+$CONFIG{ 'tag-cloud-min-size' } = 5;
+$CONFIG{ 'tag-cloud-max-size' } = 60;
 
 
 #

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -356,8 +356,6 @@ $CONFIG{ 'verbose' }      = 0;
 $CONFIG{ 'top' }          = "/";
 $CONFIG{ 'exclude-plugins' } =
   "Chronicle::Plugin::Archived,Chronicle::Plugin::Verbose";
-$CONFIG{ 'tag-cloud-min-size' } = 5;
-$CONFIG{ 'tag-cloud-max-size' } = 60;
 
 
 #

--- a/lib/Chronicle/Plugin/Generate/Tags.pm
+++ b/lib/Chronicle/Plugin/Generate/Tags.pm
@@ -194,8 +194,11 @@ sub _outputTagCloud
     #
     while ( $sql->fetch() )
     {
-        my $size = $count * 5 + 5;
-        if ( $size > 60 ) {$size = 60;}
+        my $size = $count * 5 + $config->{ 'tag-cloud-min-size' };
+        if ( $size > $config->{ 'tag-cloud-max-size' } )
+        {
+            $size = $config->{ 'tag-cloud-max-size' };
+        }
 
         push( @$tags,
               {  tag   => $tag,

--- a/lib/Chronicle/Plugin/Generate/Tags.pm
+++ b/lib/Chronicle/Plugin/Generate/Tags.pm
@@ -177,6 +177,10 @@ sub _outputTagCloud
 
     my $tags;
 
+    # Default sizing options
+    my $min  = $config->{ 'tag_cloud_size_min' }  || 5;
+    my $max  = $config->{ 'tag_cloud_size_max' }  || 60;
+    my $step = $config->{ 'tag_cloud_size_step' } || 5;
     #
     # Now the tags.
     #
@@ -194,11 +198,8 @@ sub _outputTagCloud
     #
     while ( $sql->fetch() )
     {
-        my $size = $count * 5 + $config->{ 'tag-cloud-min-size' };
-        if ( $size > $config->{ 'tag-cloud-max-size' } )
-        {
-            $size = $config->{ 'tag-cloud-max-size' };
-        }
+        my $size = $count * $step + $min;
+        $size = $max if ( $size > $max );
 
         push( @$tags,
               {  tag   => $tag,

--- a/lib/Chronicle/Plugin/Snippets/AllTags.pm
+++ b/lib/Chronicle/Plugin/Snippets/AllTags.pm
@@ -77,13 +77,17 @@ sub on_initiate
 
     my $tags;
 
+    # Default sizing options
+    my $min  = $config->{ 'tag_cloud_size_min' }  || 5;
+    my $max  = $config->{ 'tag_cloud_size_max' }  || 60;
+    my $step = $config->{ 'tag_cloud_size_step' } || 5;
     #
     # Process the results.
     #
     while ( $sql->fetch() )
     {
-        my $size = $count * 5 + 5;
-        if ( $size > 60 ) {$size = 60;}
+        my $size = $count * $step + $min;
+        $size = $max if ( $size > $max );
 
         push( @$tags,
               {  tag   => $tag,


### PR DESCRIPTION
This allows for a user to choose their min and max size of their tag cloud, We could also change the step size from 5 also but I am not sure the usefulness of this. Unless someone sets a low min and max, only yo find out they have a lot fewer steps.

Thinking about it, We could add code that a user could specify how many steps they want and the code will set up the boundaries within their limits. 