### PR TITLE
Added the StaticPage Plugin

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -20,6 +20,7 @@ lib/Chronicle/Plugin/PostBuild.pm
 lib/Chronicle/Plugin/PostSpooler.pm
 lib/Chronicle/Plugin/PreBuild.pm
 lib/Chronicle/Plugin/SkipDrafts.pm
+lib/Chronicle/Plugin/StaticPages.pm
 lib/Chronicle/Plugin/Snippets/AllTags.pm
 lib/Chronicle/Plugin/Snippets/Archives.pm
 lib/Chronicle/Plugin/Snippets/Meta.pm

--- a/lib/Chronicle/Plugin/StaticPages.pm
+++ b/lib/Chronicle/Plugin/StaticPages.pm
@@ -1,0 +1,184 @@
+
+
+=head1 NAME
+
+Chronicle::Plugin::StaticPages - Generate non-blog pages.
+
+=head1 DESCRIPTION
+
+If your blog-post contains a "C<page: 1>" header then it will
+treat the post as a non-blog static page.
+
+This contains all the methods to handle the storing and generating of
+non-blog pages. 
+
+* on_db_create: creates a table within the blog database to store the pages.
+* on_insert: inserts new and updated pages.
+* on_generate: generates the page. 
+=cut
+
+=head1 METHODS
+
+Now follows documentation on the available methods.
+
+=cut
+
+package Chronicle::Plugin::StaticPages;
+
+
+use strict;
+use warnings;
+
+=head1 doc
+
+=head2 on_db_create
+
+Create a table for the static-pages.
+
+=cut
+
+sub on_db_create
+{
+    my ( $self, %args ) = (@_);
+
+    #
+    #  Create the "pages" table
+    #
+    my $dbh = $args{ 'dbh' };
+
+    $dbh->do(
+        "CREATE TABLE pages (id INTEGER PRIMARY KEY, filename, title, content, template) "
+    );
+}
+
+
+=head2 on_insert
+
+Don't generate a blog/tag/archive entry if we have a "C<page: 1>" header,
+instead insert the post into the static-page table.
+
+=cut
+
+sub on_insert
+{
+    my ( $self, %args ) = (@_);
+
+    #
+    #  The post data, DB-handle and config.
+    #
+    my $data   = $args{ 'data' };
+    my $dbh    = $args{ 'dbh' };
+    my $config = $args{ 'config' };
+    #
+    #  Is this a page?
+    #
+    my $page = $data->{ 'page' };
+    if ($page)
+    {
+        $config->{ 'verbose' } &&
+          print "Treating page as static $data->{'file'}\n";
+
+        # if there has been no template supplied, then use the default
+        $data->{ 'template' } = 'page.tmpl'
+          unless defined $data->{ 'template' };
+
+        # because of the blog template having a default value we need to
+        # strip this and use the page default
+        $data->{ 'template' } = 'page.tmpl'
+          if $data->{ 'template' } eq 'entry.tmpl';
+
+        #
+        #  Insert into the static-pages
+        #
+        my $sql = $dbh->prepare(
+            "INSERT INTO pages (title,filename,content,template) VALUES( ?, ?, ?, ? )"
+          ) or
+          die "Failed to prepare";
+
+        $sql->execute( $data->{ 'title' },
+                       $data->{ 'link' },
+                       $data->{ 'body' },
+                       $data->{ 'template' }
+          ) or
+          die "Failed to insert";
+        $sql->finish();
+
+        #
+        #  Don't allow this to be treated as normal.
+        #
+        return undef;
+    }
+
+    # if its not a page carry on
+    else
+    {
+        #
+        #  Allow proceeding as normal
+        #
+        return ($data);
+    }
+}
+
+=head2 on_generate
+
+Generates the static page if a "C<page: 1>" 
+ header is present. The Page is processed 
+ then removed from futher processing, to avoid 
+ being treated as a blog post.
+
+=cut
+
+sub on_generate
+{
+    my ( $self, %args ) = (@_);
+
+    #
+    #  The post data, DB-handle and config.
+    #
+    my $dbh    = $args{ 'dbh' };
+    my $config = $args{ 'config' };
+
+    #
+    #  Retrive all the page data for building
+    #
+    my $pages =
+      $dbh->prepare("SELECT filename,title,content,template FROM pages") or
+      die "Failed to find static-pages";
+    $pages->execute() or die "Failed to execute query";
+
+
+    my ( $filename, $content, $title, $template );
+    $pages->bind_columns( undef, \$filename, \$title, \$content, \$template );
+
+    #
+    #   Fetach and build the files one by one
+    #
+
+    while ( my $page = $pages->fetch() )
+    {
+
+        $config->{ 'verbose' } &&
+          print "Writing Title:$title -> $config->{'output'}/$filename\n";
+
+        my $c = Chronicle::load_template($template);
+        $c->param( top => $config->{ 'top' } );
+        $c->param( { content => $content, title => $title } );
+
+        open( my $handle, ">:encoding(UTF-8)",
+              $config->{ 'output' } . "/" . $filename ) or
+          die "Failed to open";
+        print $handle $c->output();
+        close($handle);
+    }
+
+    $pages->finish();
+}
+
+sub _order
+{
+
+    return 1001;
+
+}
+
+1;

--- a/themes/bs2/page.tmpl
+++ b/themes/bs2/page.tmpl
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta name="keywords" content="">
+    <meta name="description" content="">
+    <title><!-- tmpl_var name='blog_title' --></title>
+    <link rel="shortcut icon" href="<!-- tmpL_var name='top' -->favicon.ico">
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="<!-- tmpL_var name='top' -->index.rss">
+    <link rel="stylesheet" href="<!-- tmpl_var name='top' -->css/bootstrap.css">
+    <link rel="stylesheet" href="<!-- tmpl_var name='top' -->css/mezzanine.css">
+    <link rel="stylesheet" href="<!-- tmpl_var name='top' -->css/bootstrap-responsive.css">
+    <script src="<!-- tmpl_var name='top' -->js/jquery-1.7.1.min.js"></script>
+    <script src="<!-- tmpl_var name='top' -->js/bootstrap.js"></script>
+    <script src="<!-- tmpl_var name='top' -->js/bootstrap-extras.js"></script>
+    <![if lt IE 9]>
+        <script src="<!-- tmpl_var name='top' -->js/html5shiv.js"></script>
+    <![endif]>
+  </head>
+  <body id="body">
+    <div class="navbar navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </a>
+          <a class="brand" href="<!-- tmpl_var name='top' -->"><!-- tmpl_var name='blog_title' --></a>
+          <p class="navbar-text"><!-- tmpl_var name='blog_subtitle' --></p>
+          <div class="nav-collapse collapse">
+            <form action="/search/" class="navbar-search pull-right input-append">
+              <input class="search-query" placeholder="Search" type="text" name="q" value="">
+              <input type="submit" class="btn" value="Go">
+            </form>
+            <ul class="nav pull-right"><li class=" active" id="dropdown-menu-home"><a href="<!-- tmpL_var name='top' -->">Home</a></li><li class="dropdown" id="dropdown-menu-tags"><a href="<!-- tmpL_var name='top' -->tags/">Tags</a> <li class="dropdown" id="dropdown-menu-archive"><a href="<!-- tmpL_var name='top' -->archive/">Archive</a></li><li class="divider-vertical"></li></ul>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="container">
+      <div class="row">
+        <div class="span12 middle">
+        <h1><!-- tmpl_var name='title' --></h1>
+        <!-- tmpl_var name='content' -->
+        </div>
+
+
+      </div>
+    </div>
+    <!-- tmpl_include name='inc/footer.inc' -->
+  </body>
+</html>


### PR DESCRIPTION
I have been working on StaticPages (#27). Thank you again for the gist. 

This plug-in is self contained and handles its storage and generation, because of some oddities of the Module::Pluggable::Ordered package I had to move it from Chronicle::Plugin::Generate to Chronicle::Plugin, as the generate needs run after Chronicle::Plugin::Tidy (for obvious reasons).

This is a little bit of a hack I had to introduce because of the per post templates (#31) to replace any entry.tmpl for the default page.tmpl

```perl
$data->{ 'template' } = 'page.tmpl'
      if $data->{ 'template' } eq 'entry.tmpl';
```

This will probably need a couple of clean up revision, but the code has been working nicely for  while. 

Stuart 