### PR TITLE
Added the option to have the blog posts remain in their blog dir stru…

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ lib/Chronicle/Plugin/Generate/Pages.pm
 lib/Chronicle/Plugin/Generate/RSS.pm
 lib/Chronicle/Plugin/Generate/Sitemap.pm
 lib/Chronicle/Plugin/Generate/Tags.pm
+lib/Chronicle/Plugin/InPlacePosts.pm
 lib/Chronicle/Plugin/Markdown.pm
 lib/Chronicle/Plugin/MultiMarkdown.pm
 lib/Chronicle/Plugin/PostBuild.pm

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -659,7 +659,6 @@ sub insertPost
         $meta{ 'link' } = $inplacelink . '/' . $meta{ 'title' };
     }
 
-    # die $meta{ 'link'};
     #
     #  Remove the extension - regardless of what that might be.
     #

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -404,7 +404,8 @@ updateDatabase($dbh);
 File::Path::make_path( $CONFIG{ 'output' },
                        {  verbose => 0,
                           mode    => oct("755"),
-                       } ) unless ( -d $CONFIG{ 'output' } );
+                       } )
+  unless ( -d $CONFIG{ 'output' } );
 
 
 
@@ -494,7 +495,8 @@ sub updateDatabase
         my ( $dev,   $ino,     $mode, $nlink, $uid,
              $gid,   $rdev,    $size, $atime, $mtime,
              $ctime, $blksize, $blocks
-           ) = stat($file);
+           )
+          = stat($file);
 
 
         #
@@ -644,15 +646,29 @@ sub insertPost
     #
     $meta{ 'link' } = $meta{ 'title' };
 
+    if ( $CONFIG{ 'entry_inplace' } )
+    {
+        my $inplacelink = $filename;
+
+        # strip off the source dir with the first '/'
+        # this will be added back later
+        $inplacelink =~ s?$CONFIG{'input'}/??;
+
+        # strip off the name and add the title
+        $inplacelink =~ s?/[^/]+$??;
+        $meta{ 'link' } = $inplacelink . '/' . $meta{ 'title' };
+    }
+
+    # die $meta{ 'link'};
     #
     #  Remove the extension - regardless of what that might be.
     #
     $meta{ 'link' } =~ s/\.[^.]+$//;
 
     #
-    #  Remove non-alphanumeric characters.
+    #  Remove non-alphanumeric and non '/' characters.
     #
-    $meta{ 'link' } =~ s/[^a-z0-9]/_/gi;
+    $meta{ 'link' } =~ s/[^a-z0-9\/]/_/gi;
 
     #
     #  Add the suffix for the page

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -404,8 +404,7 @@ updateDatabase($dbh);
 File::Path::make_path( $CONFIG{ 'output' },
                        {  verbose => 0,
                           mode    => oct("755"),
-                       } )
-  unless ( -d $CONFIG{ 'output' } );
+                       } ) unless ( -d $CONFIG{ 'output' } );
 
 
 
@@ -495,8 +494,7 @@ sub updateDatabase
         my ( $dev,   $ino,     $mode, $nlink, $uid,
              $gid,   $rdev,    $size, $atime, $mtime,
              $ctime, $blksize, $blocks
-           )
-          = stat($file);
+           ) = stat($file);
 
 
         #
@@ -646,28 +644,15 @@ sub insertPost
     #
     $meta{ 'link' } = $meta{ 'title' };
 
-    if ( $CONFIG{ 'entry_inplace' } )
-    {
-        my $inplacelink = $filename;
-
-        # strip off the source dir with the first '/'
-        # this will be added back later
-        $inplacelink =~ s?$CONFIG{'input'}/??;
-
-        # strip off the name and add the title
-        $inplacelink =~ s?/[^/]+$??;
-        $meta{ 'link' } = $inplacelink . '/' . $meta{ 'title' };
-    }
-
     #
     #  Remove the extension - regardless of what that might be.
     #
     $meta{ 'link' } =~ s/\.[^.]+$//;
 
     #
-    #  Remove non-alphanumeric and non '/' characters.
+    #  Remove non-alphanumeric characters.
     #
-    $meta{ 'link' } =~ s/[^a-z0-9\/]/_/gi;
+    $meta{ 'link' } =~ s/[^a-z0-9]/_/gi;
 
     #
     #  Add the suffix for the page

--- a/etc/config.sample
+++ b/etc/config.sample
@@ -39,6 +39,15 @@ input = ./blog
 # pattern = *.txt
 #
 
+#
+#  Preserve the folder structure of the input directory in the 
+# output directory. 
+# 0 = move all post to the http doc root
+# 1 = preserve the input directory structure   
+#
+# entry_inplace = 0
+#
+
 
 #
 #  The directory to write the formatted blog output to.

--- a/lib/Chronicle/Plugin/InPlacePosts.pm
+++ b/lib/Chronicle/Plugin/InPlacePosts.pm
@@ -1,0 +1,107 @@
+
+=head1 NAME
+
+Chronicle::Plugin::InPlacePosts - maintains the input directory structure.
+
+=head1 DESCRIPTION
+This plugin is designed to allow blog entries to be filtered via
+This plugin is designed to allow blog entries remain in the same
+directory structure as the input folder by adding the config 
+C<entry_inplace>.
+
+The default behaviour of chronicle is to flatten any posts 
+present in the input folder to the http doc root, however this 
+plugin sets to replicate the input folder stucture.
+
+EG
+input/
+    2015/
+        June/
+            15/
+                A_post.post
+
+
+output/
+    2015/
+        June/
+            15/
+                A_post.html
+=cut    
+
+=head1 METHODS
+
+Now follows documentation on the available methods.
+
+=cut
+
+package Chronicle::Plugin::InPlacePosts;
+
+use strict;
+use warnings;
+
+our $VERSION = "5.0.9";
+
+
+=head2 on_insert
+
+The C<on_insert> method is automatically invoked when a new blog post
+must be inserted into the SQLite database, that might be because a post
+is new, or because it has been updated.
+
+The method is designed to return an updated blog meta-data,
+after performing any massaging required.  
+
+If within the config has C<entry_inplace = 1> the posts link meta-data
+is changed to reflect the users intent to retain the posts input location.
+
+=cut
+
+sub on_insert
+{
+    my ( $self, %args ) = (@_);
+
+    my $config = $args{ 'config' };
+    my $data   = $args{ 'data' };
+
+    if ( $config->{ 'entry_inplace' } )
+    {
+        $config->{ 'verbose' }  &&
+          print "Changing Link to stay in place: $data->{'filename'} \n";
+
+        my $inplacelink = $data->{ 'filename' };
+
+        # strip off the source dir with the first '/'
+        # this will be added back later
+        my $input = $config->{'input'};
+        $inplacelink =~ s?$input/??;
+
+        # strip off the filename and add the title in its place
+        $inplacelink =~ s?/[^/]+$??;
+        $data->{ 'link' } = $inplacelink . '/' . $data->{ 'link' };
+    }
+ 
+    return ($data);
+}
+
+
+1;
+
+
+=head1 LICENSE
+
+This module is free software; you can redistribute it and/or modify it
+under the terms of either:
+
+a) the GNU General Public License as published by the Free Software
+Foundation; either version 2, or (at your option) any later version,
+or
+
+b) the Perl "Artistic License".
+
+=cut
+
+=head1 AUTHOR
+
+Stuart Skelton
+
+=cut

--- a/t/test-in-place-post.t
+++ b/t/test-in-place-post.t
@@ -1,0 +1,98 @@
+#!/usr/bin/perl -I../lib/ -Ilib/
+
+use strict;
+use warnings;
+use Test::More tests => 23;
+
+#
+#  Load the module.
+#
+BEGIN {use_ok('Chronicle::Plugin::InPlacePosts');}
+require_ok('Chronicle::Plugin::InPlacePosts');
+
+
+#
+#  Create a fake post
+#
+our %config;
+our %data;
+$config{ 'input' } = "./blog";
+
+$data{ 'body' }     = "<p>It is true</p>";
+$data{ 'date' }     = "10th March 1976";
+$data{ 'filename' } = "./blog/2015/June/13/cake.post";
+$data{ 'link' }     = "I_like_cake.html";
+$data{ 'title' }    = "I like cake";
+
+
+#
+#  Call the plugin
+#
+my $out =
+  Chronicle::Plugin::InPlacePosts::on_insert( undef,
+                                             config => \%config,
+                                             data   => \%data
+                                           );
+
+#
+#  There should be no change to our data as there is no entry_inplace.
+#
+
+ok( $out, "Returned something." );
+is( ref($out), "HASH", "Which was a hash" );
+foreach my $key ( keys %data )
+{
+    is( $data{ $key }, $out->{ $key }, "The field is unchanged: $key" );
+}
+
+
+#
+#  There should be no change to our data as entry_inplace is false
+#
+$config{ 'entry_inplace' } = 0;
+
+#
+#  Call the plugin
+#
+$out =
+  Chronicle::Plugin::InPlacePosts::on_insert( undef,
+                                             config => \%config,
+                                             data   => \%data
+                                           );
+
+ok( $out, "Returned something." );
+is( ref($out), "HASH", "Which was a hash" );
+foreach my $key ( keys %data )
+{
+    is( $data{ $key }, $out->{ $key }, "The field is unchanged: $key" );
+}
+
+#
+#  OK now make the chronicle generate the page in place.
+#
+$config{ 'entry_inplace' } = 1;
+
+#
+#  Call the plugin
+#
+$out =
+  Chronicle::Plugin::InPlacePosts::on_insert( undef,
+                                             config => \%config,
+                                             data   => \%data
+                                           );
+
+ok( $out, "Returned something." );
+is( ref($out), "HASH", "Which was a hash" );
+foreach my $key (qw(body date filename title))
+{
+    is( $data{ $key }, $out->{ $key }, "The field is unchanged: $key" );
+}
+
+#
+#  The only data that should be changed is the link.
+#  and should be changed
+#  from: 'I_like_cake.html'
+#  to:   '2015/June/13/I_like_cake.html'
+is( '2015/June/13/I_like_cake.html',
+    $out->{ link },
+    "The link field should be changed" );


### PR DESCRIPTION
…cture instead of being in the root http doc folder

This was the next stage to adding recursive entry lookups (#16), so instead of crushing all the posts to the http doc root, we now have the option for the blog structure to be preserved.

So if you have a blog structure like 
`./blog/2015/June/12/blogpost1.post`

This folder format would be preserved in the final output 
`http://yoururl.com/2015/June/12/blog1_title.html`

Its not fully tested, I just wanted to get some code up to see what you thought, as thought it could go into a early called on_insert plugin.

