### PR TITLE
Safety net for post title collisions

### DIFF
--- a/bin/chronicle
+++ b/bin/chronicle
@@ -343,18 +343,18 @@ use Chronicle::Config::Reader;
 # with previous releases of chronicle.
 #
 our %CONFIG;
-$CONFIG{ 'input' }        = "./data";
-$CONFIG{ 'pattern' }      = "*.txt";
-$CONFIG{ 'output' }       = "./output";
-$CONFIG{ 'database' }     = "./blog.db";
-$CONFIG{ 'comment-days' } = 10;
-$CONFIG{ 'entry-count' }  = 10;
-$CONFIG{ 'rss-count' }    = 10;
-$CONFIG{ 'theme-dir' }    = File::ShareDir::dist_dir('App-Chronicle');
-$CONFIG{ 'theme' }        = "default";
-$CONFIG{ 'verbose' }      = 0;
-$CONFIG{ 'top' }          = "/";
-$CONFIG{ 'exclude-plugins' } =
+$CONFIG{input}          = "./data";
+$CONFIG{pattern}        = "*.txt";
+$CONFIG{output}         = "./output";
+$CONFIG{database}       = "./blog.db";
+$CONFIG{'comment-days'} = 10;
+$CONFIG{'entry-count'}  = 10;
+$CONFIG{'rss-count'}    = 10;
+$CONFIG{'theme-dir'}    = File::ShareDir::dist_dir('App-Chronicle');
+$CONFIG{theme}          = "default";
+$CONFIG{verbose}        = 0;
+$CONFIG{top}            = "/";
+$CONFIG{'exclude-plugins'} =
   "Chronicle::Plugin::Archived,Chronicle::Plugin::Verbose";
 
 
@@ -369,7 +369,7 @@ our %GLOBAL_TEMPLATE_VARS = ();
 #
 my $cnf = Chronicle::Config::Reader->new();
 $cnf->parseFile( \%CONFIG, "/etc/chronicle/config" );
-$cnf->parseFile( \%CONFIG, $ENV{ 'HOME' } . "/.chronicle/config" );
+$cnf->parseFile( \%CONFIG, $ENV{HOME} . "/.chronicle/config" );
 
 
 #
@@ -381,8 +381,8 @@ parseCommandLine();
 #
 #  If we have a configuration file then read it.
 #
-$cnf->parseFile( \%CONFIG, $CONFIG{ 'config' } )
-  if ( defined $CONFIG{ 'config' } );
+$cnf->parseFile( \%CONFIG, $CONFIG{config} )
+  if ( defined $CONFIG{config} );
 
 
 
@@ -401,10 +401,10 @@ updateDatabase($dbh);
 #
 #  Ensure we have an output directory.
 #
-File::Path::make_path( $CONFIG{ 'output' },
+File::Path::make_path( $CONFIG{output},
                        {  verbose => 0,
                           mode    => oct("755"),
-                       } ) unless ( -d $CONFIG{ 'output' } );
+                       } ) unless ( -d $CONFIG{output} );
 
 
 
@@ -413,7 +413,7 @@ File::Path::make_path( $CONFIG{ 'output' },
 #
 foreach my $plugin ( get_plugins_for_method("on_initiate") )
 {
-    $CONFIG{ 'verbose' } && print "Calling $plugin on_initiate()\n";
+    $CONFIG{verbose} && print "Calling $plugin on_initiate()\n";
     $plugin->on_initiate( config => \%CONFIG, dbh => $dbh );
 }
 
@@ -426,7 +426,7 @@ foreach my $plugin ( get_plugins_for_method("on_initiate") )
 #
 foreach my $plugin ( get_plugins_for_method("on_generate") )
 {
-    $CONFIG{ 'verbose' } && print "Calling $plugin on_generate()\n";
+    $CONFIG{verbose} && print "Calling $plugin on_generate()\n";
     $plugin->on_generate( config => \%CONFIG, dbh => $dbh );
 }
 
@@ -434,7 +434,7 @@ foreach my $plugin ( get_plugins_for_method("on_generate") )
 #
 #  Copy any static content from the theme-directory.
 #
-my $ts = $CONFIG{ 'theme-dir' } . "/" . $CONFIG{ 'theme' } . "/static";
+my $ts = $CONFIG{'theme-dir'} . "/" . $CONFIG{theme} . "/static";
 if ( -d $ts )
 {
 
@@ -442,7 +442,7 @@ if ( -d $ts )
     #  This could be improved, but it will cope with subdirectories, etc,
     # so for the moment it will remain.
     #
-    system("/bin/tar -C $ts -cpf - . | /bin/tar -C $CONFIG{'output'} -xf -");
+    system("/bin/tar -C $ts -cpf - . | /bin/tar -C $CONFIG{output} -xf -");
 }
 
 
@@ -485,7 +485,7 @@ sub updateDatabase
     #
 
     foreach
-      my $file ( get_post_files( $CONFIG{ 'input' }, $CONFIG{ 'pattern' } ) )
+      my $file ( get_post_files( $CONFIG{input}, $CONFIG{pattern} ) )
     {
 
         #
@@ -537,7 +537,7 @@ sub insertPost
 {
     my ( $dbh, $filename, $mtime ) = (@_);
 
-    $CONFIG{ 'verbose' } && print "Adding post to DB: $filename\n";
+    $CONFIG{verbose} && print "Adding post to DB: $filename\n";
 
     #
     #  Is the entry present, but with a different mtime?
@@ -552,7 +552,7 @@ sub insertPost
 
     while ( $sql->fetch() )
     {
-        $CONFIG{ 'verbose' } && print "Replacing DB post: $id\n";
+        $CONFIG{verbose} && print "Replacing DB post: $id\n";
 
         #
         #  Delete the tags referring to this old post.
@@ -628,47 +628,47 @@ sub insertPost
         }
         else
         {
-            $meta{ 'body' } .= $line;
+            $meta{body} .= $line;
         }
     }
     close($handle);
 
     # initicate the truncated body.
-    $meta{ 'truncatedbody' } = '';
+    $meta{truncatedbody} = '';
 
     # initicate the template and change if there is a template is supplied.
-    $meta{ 'template' } = "entry.tmpl" unless defined $meta{ 'template' };
+    $meta{template} = "entry.tmpl" unless defined $meta{template};
 
     #
     #  Generate the link from the title of the post.
     #
-    $meta{ 'link' } = $meta{ 'title' };
+    $meta{link} = $meta{title};
 
     #
     #  Remove the extension - regardless of what that might be.
     #
-    $meta{ 'link' } =~ s/\.[^.]+$//;
+    $meta{link} =~ s/\.[^.]+$//;
 
     #
     #  Remove non-alphanumeric characters.
     #
-    $meta{ 'link' } =~ s/[^a-z0-9]/_/gi;
+    $meta{link} =~ s/[^a-z0-9]/_/gi;
 
     #
     #  Add the suffix for the page
     #
-    my $suffix = $CONFIG{ 'entry_suffix' } || ".html";
-    $meta{ 'link' } .= $suffix;
+    my $suffix = $CONFIG{entry_suffix} || ".html";
+    $meta{link} .= $suffix;
 
     #
     #  Lower-case
     #
-    $meta{ 'link' } = lc( $meta{ 'link' } );
+    $meta{link} = lc( $meta{link} );
 
     #
     #  Let any plugins have access to the filename.
     #
-    $meta{ 'file' } = $filename;
+    $meta{file} = $filename;
 
     #
     #  Are we going to skip this post?
@@ -680,7 +680,7 @@ sub insertPost
     #
     foreach my $plugin ( get_plugins_for_method("on_insert") )
     {
-        $CONFIG{ 'verbose' } && print "Calling $plugin - on_insert\n";
+        $CONFIG{verbose} && print "Calling $plugin - on_insert\n";
         my $m = $plugin->on_insert( config => \%CONFIG,
                                     dbh    => $dbh,
                                     data   => \%meta
@@ -713,7 +713,7 @@ sub insertPost
 
     if ($skip)
     {
-        $CONFIG{ 'verbose' } && print "Skipping post: $filename\n";
+        $CONFIG{verbose} && print "Skipping post: $filename\n";
         return;
     }
 
@@ -721,13 +721,13 @@ sub insertPost
     #
     #  Convert the date to a seconds past epoch.
     #
-    if ( !$meta{ 'date' } )
+    if ( !$meta{date} )
     {
         die "Post is missing a date header - $filename\n";
     }
     else
     {
-        $meta{ 'date' } = str2time( $meta{ 'date' } );
+        $meta{date} = str2time( $meta{date} );
     }
 
     #
@@ -739,13 +739,13 @@ sub insertPost
       die "Failed to prepare";
 
     $post_add->execute( $filename,
-                        $meta{ 'date' },
-                        $meta{ 'title' },
-                        $meta{ 'link' },
+                        $meta{date},
+                        $meta{title},
+                        $meta{link},
                         $mtime,
-                        $meta{ 'body' },
-                        $meta{ 'truncatedbody' },
-                        $meta{ 'template' }
+                        $meta{body},
+                        $meta{truncatedbody},
+                        $meta{template}
       ) or
       die "Failed to insert:" . $dbh->errstr();
 
@@ -755,13 +755,13 @@ sub insertPost
     #
     #  Add any tags the post might contain.
     #
-    if ( $meta{ 'tags' } )
+    if ( $meta{tags} )
     {
         my $tag_add =
           $dbh->prepare("INSERT INTO tags (blog_id, name) VALUES( ?,?)") or
           die "Failed to prepare";
 
-        foreach my $tag ( split( /,/, $meta{ 'tags' } ) )
+        foreach my $tag ( split( /,/, $meta{tags} ) )
         {
 
             # strip leading and trailing space.
@@ -805,15 +805,15 @@ sub getDatabase
     #  Ensure we have something specified.
     #
     die "No database configured - please use --database=/path/tocreate"
-      unless ( $CONFIG{ 'database' } );
+      unless ( $CONFIG{database} );
 
     #
     #  Does it exist?
     #
-    $present = 1 if ( -e $CONFIG{ 'database' } );
+    $present = 1 if ( -e $CONFIG{database} );
 
 
-    my $dbh = DBI->connect( "dbi:SQLite:dbname=$CONFIG{'database'}", "", "" );
+    my $dbh = DBI->connect( "dbi:SQLite:dbname=$CONFIG{database}", "", "" );
 
     $dbh->{ sqlite_unicode } = 1;
 
@@ -828,7 +828,7 @@ sub getDatabase
 
         foreach my $plugin ( get_plugins_for_method("on_db_create") )
         {
-            $CONFIG{ 'verbose' } && print "Calling $plugin - on_db_create\n";
+            $CONFIG{verbose} && print "Calling $plugin - on_db_create\n";
             $plugin->on_db_create( config => \%CONFIG,
                                    dbh    => $dbh, );
         }
@@ -838,7 +838,7 @@ sub getDatabase
 
     foreach my $plugin ( get_plugins_for_method("on_db_load") )
     {
-        $CONFIG{ 'verbose' } && print "Calling $plugin - on_db_load\n";
+        $CONFIG{verbose} && print "Calling $plugin - on_db_load\n";
         $plugin->on_db_load( config => \%CONFIG,
                              dbh    => $dbh, );
     }
@@ -863,14 +863,14 @@ sub getBlog
     #
     #  These are compulsary
     #
-    my $dbh = $params{ 'dbh' } || die "Missing database handle";
-    my $id  = $params{ 'id' }  || die "Missing ID";
+    my $dbh = $params{dbh} || die "Missing database handle";
+    my $id  = $params{id}  || die "Missing ID";
 
     #
     #  This is optional, and present so that the date/time format
     # may be changed by the user in their configuration file.
     #
-    my $config = $params{ 'config' } || undef;
+    my $config = $params{config} || undef;
 
 
     #
@@ -895,9 +895,9 @@ sub getBlog
     $tags->bind_columns( undef, \$name );
     while ( $tags->fetch() )
     {
-        my $x = $data->{ 'tags' };
+        my $x = $data->{tags};
         push( @$x, { tag => $name } );
-        $data->{ 'tags' } = $x;
+        $data->{tags} = $x;
     }
     $tags->finish();
 
@@ -909,15 +909,15 @@ sub getBlog
     #  If the date is not set then we use the mtime for both date & time.
     #
     my $time;
-    my $posted = $data->{ 'date' };
-    $data->{ 'posted' } = $data->{ 'date' };
-    if ( $data->{ 'date' } )
+    my $posted = $data->{date};
+    $data->{posted} = $data->{date};
+    if ( $data->{date} )
     {
-        $time = $data->{ 'date' };
+        $time = $data->{date};
     }
     else
     {
-        $time = $data->{ 'mtime' };
+        $time = $data->{mtime};
     }
 
 
@@ -949,7 +949,7 @@ sub getBlog
     #
     if ( $date_fmt && length($date_fmt) )
     {
-        $data->{ 'date' } = time2str( $date_fmt, $time );
+        $data->{date} = time2str( $date_fmt, $time );
     }
 
     #
@@ -962,30 +962,30 @@ sub getBlog
         #
         #  The time from the import-date.
         #
-        $data->{ 'time' } = time2str( $time_fmt, $time );
+        $data->{time} = time2str( $time_fmt, $time );
 
         #
         #  If that failed then from the modification-time.
         #
-        if ( $data->{ 'time' } =~ /00:00:00/ )
+        if ( $data->{time} =~ /00:00:00/ )
         {
-            $data->{ 'time' } = time2str( $time_fmt, $data->{ 'mtime' } );
+            $data->{time} = time2str( $time_fmt, $data->{mtime} );
         }
     }
 
     #
     #  If comments are enabled then populate the blog-post with them too.
     #
-    if ( $CONFIG{ 'comments' } )
+    if ( $CONFIG{comments} )
     {
-        my $comments = getComments( $data->{ 'link' } );
+        my $comments = getComments( $data->{link} );
         if ($comments)
         {
-            $data->{ 'comments' } = $comments;
+            $data->{comments} = $comments;
 
             my $count = scalar(@$comments);
-            $data->{ 'comment_count' }  = $count;
-            $data->{ 'comment_plural' } = 1
+            $data->{comment_count}  = $count;
+            $data->{comment_plural} = 1
               if ( ( $count == 0 ) || ( $count > 1 ) );
         }
 
@@ -997,15 +997,15 @@ sub getBlog
         #
         my $now = time;
         my $ago = $now - $posted;
-        my $age = ( ( 60 * 60 * 24 ) * ( $CONFIG{ 'comment-days' } ) );
+        my $age = ( ( 60 * 60 * 24 ) * ( $CONFIG{'comment-days'} ) );
 
         if ( $ago < $age )
         {
-            $data->{ 'comments_enabled' } = 1;
+            $data->{comments_enabled} = 1;
         }
         else
         {
-            $data->{ 'comments_enabled' } = undef;
+            $data->{comments_enabled} = undef;
         }
     }
 
@@ -1030,13 +1030,13 @@ sub getComments
     #
     #  If there is no comment-directory setup then return nothing.
     #
-    return unless ( $CONFIG{ 'comments' } );
+    return unless ( $CONFIG{comments} );
 
     #
     #  If there is a comment-directory setup, but it doesn't exist
     # then again we do nothing.
     #
-    return unless ( -d $CONFIG{ 'comments' } );
+    return unless ( -d $CONFIG{comments} );
 
 
     my $results;
@@ -1051,7 +1051,7 @@ sub getComments
     #
     my @entries;
     foreach
-      my $file ( sort( glob( $CONFIG{ 'comments' } . "/" . $title . "*" ) ) )
+      my $file ( sort( glob( $CONFIG{comments} . "/" . $title . "*" ) ) )
     {
         push( @entries, $file );
     }
@@ -1139,8 +1139,8 @@ sub getComments
             #
             my $author = 0;
             $author = 1
-              if ( $CONFIG{ 'author' } &&
-                   ( lc($mail) eq lc( $CONFIG{ 'author' } ) ) );
+              if ( $CONFIG{author} &&
+                   ( lc($mail) eq lc( $CONFIG{author} ) ) );
 
             #
             # Store the comment
@@ -1158,7 +1158,7 @@ sub getComments
         }
         else
         {
-            $CONFIG{ 'verbose' } &&
+            $CONFIG{verbose} &&
               print
               "I didn't like length of \$name ($name), \$mail ($mail) or \$body ($body)\n";
         }
@@ -1191,23 +1191,23 @@ sub load_template
     #  Ensure we have a theme.
     #
     die "You must specify a theme with --theme"
-      unless ( $CONFIG{ 'theme' } );
+      unless ( $CONFIG{theme} );
 
     #
     #  Ensure things exist.
     #
     die "The theme directory specified with 'theme-dir' doesn't exist"
-      unless ( -d $CONFIG{ 'theme-dir' } );
+      unless ( -d $CONFIG{'theme-dir'} );
 
     die
-      "The theme '$CONFIG{'theme'}' doesn't exist beneath $CONFIG{'theme-dir'}!"
-      unless ( -d $CONFIG{ 'theme-dir' } . "/" . $CONFIG{ 'theme' } );
+      "The theme '$CONFIG{theme}' doesn't exist beneath $CONFIG{'theme-dir'}!"
+      unless ( -d $CONFIG{'theme-dir'} . "/" . $CONFIG{theme} );
 
 
     #
     #  HTML::Template options
     #
-    my %options = ( path => [$CONFIG{ 'theme-dir' } . "/" . $CONFIG{ 'theme' }],
+    my %options = ( path => [$CONFIG{'theme-dir'} . "/" . $CONFIG{theme}],
                     die_on_bad_params => 0,
                     loop_context_vars => 1,
                     global_vars       => 1,
@@ -1223,7 +1223,7 @@ sub load_template
     {
 
         my $path =
-          $CONFIG{ 'theme-dir' } . "/" . $CONFIG{ 'theme' } . "/" . $filename;
+          $CONFIG{'theme-dir'} . "/" . $CONFIG{theme} . "/" . $filename;
 
         #
         #  If the template doesn't exist return undef.
@@ -1252,10 +1252,10 @@ sub load_template
     #
     #  Legacy options.
     #
-    $tmpl->param( blog_title => $CONFIG{ 'blog_title' } )
-      if ( $CONFIG{ 'blog_title' } );
-    $tmpl->param( blog_subtitle => $CONFIG{ 'blog_subtitle' } )
-      if ( $CONFIG{ 'blog_subtitle' } );
+    $tmpl->param( blog_title => $CONFIG{blog_title} )
+      if ( $CONFIG{blog_title} );
+    $tmpl->param( blog_subtitle => $CONFIG{blog_subtitle} )
+      if ( $CONFIG{blog_subtitle} );
 
     #
     #  Global options, such as build-time, build-date, etc.
@@ -1289,41 +1289,41 @@ sub parseCommandLine
             # Help options
             "help",    \$HELP,
             "manual",  \$MANUAL,
-            "verbose", \$CONFIG{ 'verbose' },
-            "version", \$CONFIG{ 'version' },
+            "verbose", \$CONFIG{verbose},
+            "version", \$CONFIG{version},
 
             # theme support
-            "theme=s",     \$CONFIG{ 'theme' },
-            "theme-dir=s", \$CONFIG{ 'theme-dir' },
-            "list-themes", \$CONFIG{ 'list-themes' },
+            "theme=s",     \$CONFIG{theme},
+            "theme-dir=s", \$CONFIG{'theme-dir'},
+            "list-themes", \$CONFIG{'list-themes'},
 
             # paths
-            "input=s",    \$CONFIG{ 'input' },
-            "output=s",   \$CONFIG{ 'output' },
-            "pattern=s",  \$CONFIG{ 'pattern' },
-            "comments=s", \$CONFIG{ 'comments' },
+            "input=s",    \$CONFIG{input},
+            "output=s",   \$CONFIG{output},
+            "pattern=s",  \$CONFIG{pattern},
+            "comments=s", \$CONFIG{comments},
 
             # limits
-            "entry-count=s", \$CONFIG{ 'entry-count' },
-            "rss-count=s",   \$CONFIG{ 'rss-count' },
+            "entry-count=s", \$CONFIG{'entry-count'},
+            "rss-count=s",   \$CONFIG{'rss-count'},
 
             # optional
-            "config=s",       \$CONFIG{ 'config' },
-            "database=s",     \$CONFIG{ 'database' },
-            "author=s",       \$CONFIG{ 'author' },
-            "comment-days=s", \$CONFIG{ 'comment-days' },
-            "force",          \$CONFIG{ 'force' },
+            "config=s",       \$CONFIG{config},
+            "database=s",     \$CONFIG{database},
+            "author=s",       \$CONFIG{author},
+            "comment-days=s", \$CONFIG{'comment-days'},
+            "force",          \$CONFIG{force},
 
             # plugins
-            "list-plugins",      \$CONFIG{ 'list-plugins' },
-            "exclude-plugins=s", \$CONFIG{ 'exclude-plugins' },
+            "list-plugins",      \$CONFIG{'list-plugins'},
+            "exclude-plugins=s", \$CONFIG{'exclude-plugins'},
 
             # title
-            "blog-title=s",    \$CONFIG{ 'blog_title' },
-            "blog-subtitle=s", \$CONFIG{ 'blog_subtitle' },
+            "blog-title=s",    \$CONFIG{blog_title},
+            "blog-subtitle=s", \$CONFIG{blog_subtitle},
 
             # prefix
-            "url-prefix=s", \$CONFIG{ 'top' },
+            "url-prefix=s", \$CONFIG{top},
 
         ) )
     {
@@ -1336,7 +1336,7 @@ sub parseCommandLine
     #
     #  Show our version number, and terminate.
     #
-    if ( $CONFIG{ 'version' } )
+    if ( $CONFIG{version} )
     {
         print "Chronicle $VERSION\n";
         exit(0);
@@ -1345,7 +1345,7 @@ sub parseCommandLine
     #
     #  List themes.
     #
-    if ( $CONFIG{ 'list-themes' } )
+    if ( $CONFIG{'list-themes'} )
     {
 
         #
@@ -1358,9 +1358,9 @@ sub parseCommandLine
         #
         my @dirs = ();
         push( @dirs, $global );
-        if ( $CONFIG{ 'theme-dir' } && ( $CONFIG{ 'theme-dir' } ne $global ) )
+        if ( $CONFIG{'theme-dir'} && ( $CONFIG{'theme-dir'} ne $global ) )
         {
-            push( @dirs, $CONFIG{ 'theme-dir' } );
+            push( @dirs, $CONFIG{'theme-dir'} );
         }
 
         #
@@ -1382,13 +1382,13 @@ sub parseCommandLine
     #
     #  List plugins
     #
-    if ( $CONFIG{ 'list-plugins' } )
+    if ( $CONFIG{'list-plugins'} )
     {
         for my $plugin ( Chronicle->plugins_ordered() )
         {
             print $plugin . "\n";
 
-            if ( $CONFIG{ 'verbose' } )
+            if ( $CONFIG{verbose} )
             {
                 foreach my $method (
                     sort
@@ -1432,9 +1432,9 @@ sub get_plugins_for_method
     {
         my $skip = 0;
 
-        if ( $CONFIG{ 'exclude-plugins' } )
+        if ( $CONFIG{'exclude-plugins'} )
         {
-            foreach my $exclude ( split( /,/, $CONFIG{ 'exclude-plugins' } ) )
+            foreach my $exclude ( split( /,/, $CONFIG{'exclude-plugins'} ) )
             {
 
                 # strip leading and trailing space.
@@ -1446,7 +1446,7 @@ sub get_plugins_for_method
 
                 if ( $plugin =~ /\Q$exclude\E/i )
                 {
-                    $CONFIG{ 'verbose' } && print "Skipping plugin: $plugin\n";
+                    $CONFIG{verbose} && print "Skipping plugin: $plugin\n";
                     $skip = 1;
                 }
             }

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -821,7 +821,11 @@ sub getDatabase
     {
 
         $dbh->do(
-            "CREATE TABLE blog (id INTEGER PRIMARY KEY, file, date,title, link,mtime, body, truncatedbody, template );"
+            "CREATE TABLE blog (id INTEGER PRIMARY KEY,file,date,title,link,mtime,body,truncatedbody,template);"
+        );
+        # Make sure the titles are unique because they are used to construct file names
+        $dbh->do(
+            "CREATE UNIQUE INDEX unique_title on blog (title);"
         );
         $dbh->do("CREATE TABLE tags (id INTEGER PRIMARY KEY, name, blog_id );");
 

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -633,10 +633,12 @@ sub insertPost
     }
     close($handle);
 
+    defined $meta{title} or die "Missing `Title:' line in `$filename'";
+
     # initicate the truncated body.
     $meta{truncatedbody} = '';
 
-    # initicate the template and change if there is a template is supplied.
+    # initiate the template and change if there is a template supplied.
     $meta{template} = "entry.tmpl" unless defined $meta{template};
 
     #

--- a/lib/Chronicle/Plugin/Archived.pm
+++ b/lib/Chronicle/Plugin/Archived.pm
@@ -56,14 +56,14 @@ sub on_insert
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
-    my $data   = $args{ 'data' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
+    my $data   = $args{data};
 
     #
     #  Convert the date of the post to a seconds past epoch.
     #
-    my $date = str2time( $data->{ 'date' } );
+    my $date = str2time( $data->{date} );
 
     #
     #  Now build up a new prefix for the file
@@ -73,7 +73,7 @@ sub on_insert
     #
     #  And prepend that to the link.
     #
-    $data->{ 'link' } = $date . $data->{ 'link' };
+    $data->{link} = $date . $data->{link};
 
     return ($data);
 }

--- a/lib/Chronicle/Plugin/DBTweak.pm
+++ b/lib/Chronicle/Plugin/DBTweak.pm
@@ -44,7 +44,7 @@ sub on_db_load
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh = $args{ 'dbh' };
+    my $dbh = $args{dbh};
 
     $dbh->do("PRAGMA synchronous = OFF");
     $dbh->do("PRAGMA cache_size = 400000");

--- a/lib/Chronicle/Plugin/Filter.pm
+++ b/lib/Chronicle/Plugin/Filter.pm
@@ -86,8 +86,8 @@ sub on_insert
 {
     my ( $self, %args ) = (@_);
 
-    my $conf = $args{ 'config' };
-    my $data = $args{ 'data' };
+    my $conf = $args{config};
+    my $data = $args{data};
 
     #
     #  The filters we run.
@@ -114,13 +114,13 @@ sub on_insert
         #
         #  Get the post body
         #
-        my $body = $data->{ 'body' };
+        my $body = $data->{body};
 
         #
         #  Report what we're doing.
         #
-        print "Filtering $data->{'file'} via $filter\n"
-          if ( $conf->{ 'verbose' } );
+        print "Filtering $data->{file} via $filter\n"
+          if ( $conf->{verbose} );
 
 
         #
@@ -145,7 +145,7 @@ sub on_insert
         #
         #  Store the updated body.
         #
-        $data->{ 'body' } = $result;
+        $data->{body} = $result;
     }
 
     #

--- a/lib/Chronicle/Plugin/Generate/Archive.pm
+++ b/lib/Chronicle/Plugin/Generate/Archive.pm
@@ -64,13 +64,13 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
     #
     #  Get our language
     #
-    my $language = $ENV{ 'MONTHS' } || "English";
+    my $language = $ENV{MONTHS} || "English";
 
     #
     #  Now populate @MONTHS with the month names of that language.
@@ -136,9 +136,9 @@ sub on_generate
     }
 
 
-    if ( !-d "$config->{'output'}/archive/" )
+    if ( !-d "$config->{output}/archive/" )
     {
-        File::Path::make_path( "$config->{'output'}/archive/",
+        File::Path::make_path( "$config->{output}/archive/",
                                {  verbose => 0,
                                   mode    => oct("755"),
                                } );
@@ -147,17 +147,17 @@ sub on_generate
     #
     #  The index file to generate
     #
-    my $index = $config->{ 'index_filename' } || "index.html";
+    my $index = $config->{index_filename} || "index.html";
 
     my $c = Chronicle::load_template("archive_index.tmpl");
     if ($c)
     {
-        $config->{ 'verbose' } &&
-          print "Creating : $config->{'output'}/archive/$index\n";
-        $c->param( top => $config->{ 'top' } );
+        $config->{verbose} &&
+          print "Creating : $config->{output}/archive/$index\n";
+        $c->param( top => $config->{top} );
         $c->param( archive => $data ) if ($data);
         open( my $handle, ">:encoding(UTF-8)",
-              "$config->{'output'}/archive/$index" ) or
+              "$config->{output}/archive/$index" ) or
           die "Failed to open";
         print $handle $c->output();
         close($handle);
@@ -189,10 +189,10 @@ sub on_generate
 
         # skip if it exists.
         next
-          if ( ( -e "$config->{'output'}/archive/$year/$mon" ) &&
-               ( !$config->{ 'force' } ) );
+          if ( ( -e "$config->{output}/archive/$year/$mon" ) &&
+               ( !$config->{force} ) );
 
-        File::Path::make_path( "$config->{'output'}/archive/$year/$mon",
+        File::Path::make_path( "$config->{output}/archive/$year/$mon",
                                {  verbose => 0,
                                   mode    => oct("755"),
                                } );
@@ -211,19 +211,19 @@ sub on_generate
         $ids->finish();
 
 
-        $config->{ 'verbose' } &&
-          print "Creating : $config->{'output'}/archive/$year/$mon/$index\n";
+        $config->{verbose} &&
+          print "Creating : $config->{output}/archive/$year/$mon/$index\n";
 
 
         $c = Chronicle::load_template("/archive.tmpl");
         return if ( !$c );
 
-        $c->param( top        => $config->{ 'top' } );
+        $c->param( top        => $config->{top} );
         $c->param( entries    => $entries );
         $c->param( month      => $mon, year => $year );
         $c->param( month_name => $MONTHS[$mon - 1] );
         open( my $handle, ">:encoding(UTF-8)",
-              "$config->{'output'}/archive/$year/$mon/$index" ) or
+              "$config->{output}/archive/$year/$mon/$index" ) or
           die "Failed to open";
         print $handle $c->output();
         close($handle);

--- a/lib/Chronicle/Plugin/Generate/Index.pm
+++ b/lib/Chronicle/Plugin/Generate/Index.pm
@@ -45,14 +45,14 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
 
     #
     #  The number of posts to show on the front-page
     #
-    my $count = $config->{ 'entry-count' } || 10;
+    my $count = $config->{'entry-count'} || 10;
 
     my $recent =
       $dbh->prepare("SELECT id FROM blog ORDER BY date DESC LIMIT 0,$count") or
@@ -79,17 +79,17 @@ sub on_generate
     #
     #  The index-file to generate
     #
-    my $index = $config->{ 'index_filename' } || "index.html";
+    my $index = $config->{index_filename} || "index.html";
 
-    $config->{ 'verbose' } &&
-      print "Creating : $config->{'output'}/$index\n";
+    $config->{verbose} &&
+      print "Creating : $config->{output}/$index\n";
 
     my $c = Chronicle::load_template("index.tmpl");
     return unless ($c);
 
-    $c->param( top => $config->{ 'top' } );
+    $c->param( top => $config->{top} );
     $c->param( entries => $entries ) if ($entries);
-    open( my $handle, ">:encoding(UTF-8)", "$config->{'output'}/$index" ) or
+    open( my $handle, ">:encoding(UTF-8)", "$config->{output}/$index" ) or
       die "Failed to open";
     print $handle $c->output();
     close($handle);

--- a/lib/Chronicle/Plugin/Generate/Pages.pm
+++ b/lib/Chronicle/Plugin/Generate/Pages.pm
@@ -57,8 +57,8 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
 
     my $all = $dbh->prepare("SELECT id FROM blog ORDER BY date ASC") or
@@ -112,7 +112,7 @@ sub on_generate
         #
         #  Work out where it will be written to
         #
-        my $out = $config->{ 'output' } . "/" . $entry->{ 'link' };
+        my $out = $config->{output} . "/" . $entry->{link};
 
         #
         #  We skip posts that are already present:
@@ -134,16 +134,16 @@ sub on_generate
         #
         # Unless --force overrides that.
         #
-        $skip = 0 if ( $config->{ 'force' } );
+        $skip = 0 if ( $config->{force} );
 
         #
         # Finally if comments were enabled and this is recent then
         # we'll also force it to be generated
         #
         $skip = 0
-          if ( ( $config->{ 'comments' } ) &&
-               ( ( $now - $entry->{ 'posted' } ) <
-                 ( 60 * 60 * 24 * $config->{ 'comment-days' } ) ) );
+          if ( ( $config->{comments} ) &&
+               ( ( $now - $entry->{posted} ) <
+                 ( 60 * 60 * 24 * $config->{'comment-days'} ) ) );
 
 
         #
@@ -152,12 +152,12 @@ sub on_generate
         next if ($skip);
 
 
-        $config->{ 'verbose' } &&
-          print "Creating : $config->{'output'}/$entry->{'link'}\n";
+        $config->{verbose} &&
+          print "Creating : $config->{output}/$entry->{link}\n";
 
-        my $c = Chronicle::load_template( $entry->{ 'template' } );
+        my $c = Chronicle::load_template( $entry->{template} );
         return unless ($c);
-        $c->param( top => $config->{ 'top' } );
+        $c->param( top => $config->{top} );
         $c->param($entry);
 
         #
@@ -171,8 +171,8 @@ sub on_generate
                                   config => $config
                                 );
             $c->param( prev_id    => $prev_id,
-                       prev_title => $prev->{ 'title' },
-                       prev_link  => $prev->{ 'link' } );
+                       prev_title => $prev->{title},
+                       prev_link  => $prev->{link} );
         }
         if ($next_id)
         {
@@ -182,15 +182,15 @@ sub on_generate
                                   config => $config
                                 );
             $c->param( next_id    => $next_id,
-                       next_title => $next->{ 'title' },
-                       next_link  => $next->{ 'link' } );
+                       next_title => $next->{title},
+                       next_link  => $next->{link} );
         }
 
         #
         #  Ensure we have a full output path - because a plugin might have given us a dated-path.
         #
         my $dir = File::Basename::dirname(
-                             $config->{ 'output' } . "/" . $entry->{ 'link' } );
+                             $config->{output} . "/" . $entry->{link} );
         if ( !-d $dir )
         {
             File::Path::make_path( $dir,
@@ -200,7 +200,7 @@ sub on_generate
         }
 
         open( my $handle, ">:encoding(UTF-8)",
-              $config->{ 'output' } . "/" . $entry->{ 'link' } ) or
+              $config->{output} . "/" . $entry->{link} ) or
           die "Failed to open";
         print $handle $c->output();
         close($handle);

--- a/lib/Chronicle/Plugin/Generate/RSS.pm
+++ b/lib/Chronicle/Plugin/Generate/RSS.pm
@@ -53,8 +53,8 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
     my $recent = $dbh->prepare(
         "SELECT id FROM blog ORDER BY date DESC LIMIT 0,$config->{'rss-count'}")
@@ -79,8 +79,8 @@ sub on_generate
     $recent->finish();
 
 
-    $config->{ 'verbose' } &&
-      print "Creating : $config->{'output'}/index.rss\n";
+    $config->{verbose} &&
+      print "Creating : $config->{output}/index.rss\n";
 
 
     #
@@ -122,13 +122,13 @@ sub on_generate
     #
     #  Add the entries.
     #
-    $c->param( top => $config->{ 'top' } );
+    $c->param( top => $config->{top} );
     $c->param( entries => $entries ) if ($entries);
 
     #
     #  Output the rendered template.
     #
-    open( my $handle, ">:encoding(UTF-8)", "$config->{'output'}/index.rss" ) or
+    open( my $handle, ">:encoding(UTF-8)", "$config->{output}/index.rss" ) or
       die "Failed to open";
     print $handle $c->output();
     close($handle);
@@ -137,10 +137,10 @@ sub on_generate
     #
     #  Show the number of entries written if we're being verbose.
     #
-    if ( $config->{ 'verbose' } && $entries )
+    if ( $config->{verbose} && $entries )
     {
         print "Wrote " . scalar(@$entries) .
-          " items to $config->{'output'}/index.rss\n";
+          " items to $config->{output}/index.rss\n";
     }
 }
 

--- a/lib/Chronicle/Plugin/Generate/Sitemap.pm
+++ b/lib/Chronicle/Plugin/Generate/Sitemap.pm
@@ -62,8 +62,8 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
 
     #
@@ -80,7 +80,7 @@ sub on_generate
     #
     #  This is the file we're going to write.
     #
-    my $output = $config->{ 'output' } . "/sitemap.xml";
+    my $output = $config->{output} . "/sitemap.xml";
 
     my $sql = $dbh->prepare("SELECT link FROM blog") or
       die "Failed to prepare: " . $dbh->errstr();
@@ -94,7 +94,7 @@ sub on_generate
 
     while ( $sql->fetch() )
     {
-        push( @$urls, { url => $config->{ 'top' } . $link } );
+        push( @$urls, { url => $config->{top} . $link } );
     }
     $sql->finish();
 
@@ -104,14 +104,14 @@ sub on_generate
     #
     my $template = Chronicle::load_template( undef, $tmpl );
     $template->param( urls => $urls ) if ($urls);
-    $template->param( top => $config->{ 'top' } ) if ( $config->{ 'top' } );
+    $template->param( top => $config->{top} ) if ( $config->{top} );
 
     open( my $handle, ">:encoding(UTF-8)", $output ) or
       die "Failed to open output file $output - $!";
     print $handle $template->output();
     close($handle);
 
-    if ( $config->{ 'verbose' } )
+    if ( $config->{verbose} )
     {
         print "Wrote " . ( $urls ? scalar(@$urls) : 0 ) . " URLS to $output\n";
     }

--- a/lib/Chronicle/Plugin/Generate/Tags.pm
+++ b/lib/Chronicle/Plugin/Generate/Tags.pm
@@ -60,8 +60,8 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
 
     _outputTags( $config, $dbh );
@@ -100,19 +100,19 @@ sub _outputTags
 
         # skip if it exists.
         next
-          if ( ( -e $config->{ 'output' } . "/tags/$tag" ) &&
-               ( !$config->{ 'force' } ) );
+          if ( ( -e $config->{output} . "/tags/$tag" ) &&
+               ( !$config->{force} ) );
 
 
         #
         #  The output file to generate
         #
-        my $index = $config->{ 'index_filename' } || "index.html";
+        my $index = $config->{index_filename} || "index.html";
 
-        $config->{ 'verbose' } &&
-          print "Creating : $config->{'output'}/tags/$tag/$index\n";
+        $config->{verbose} &&
+          print "Creating : $config->{output}/tags/$tag/$index\n";
 
-        File::Path::make_path( "$config->{'output'}/tags/$tag",
+        File::Path::make_path( "$config->{output}/tags/$tag",
                                {  verbose => 0,
                                   mode    => oct("755"),
                                } );
@@ -142,11 +142,11 @@ sub _outputTags
         my $c = Chronicle::load_template("tag.tmpl");
         return unless ($c);
 
-        $c->param( top     => $config->{ 'top' } );
+        $c->param( top     => $config->{top} );
         $c->param( entries => $entries ) if ($entries);
         $c->param( tag     => $tag );
         open( my $handle, ">:encoding(UTF-8)",
-              "$config->{'output'}/tags/$tag/$index" ) or
+              "$config->{output}/tags/$tag/$index" ) or
           die "Failed to open";
         print $handle $c->output();
         close($handle);
@@ -178,9 +178,9 @@ sub _outputTagCloud
     my $tags;
 
     # Default sizing options
-    my $min  = $config->{ 'tag_cloud_size_min' }  || 5;
-    my $max  = $config->{ 'tag_cloud_size_max' }  || 60;
-    my $step = $config->{ 'tag_cloud_size_step' } || 5;
+    my $min  = $config->{tag_cloud_size_min}  || 5;
+    my $max  = $config->{tag_cloud_size_max}  || 60;
+    my $step = $config->{tag_cloud_size_step} || 5;
 
     #
     # Now the tags.
@@ -215,15 +215,15 @@ sub _outputTagCloud
     #
     #  The output file to generate
     #
-    my $index = $config->{ 'index_filename' } || "index.html";
+    my $index = $config->{index_filename} || "index.html";
 
-    $config->{ 'verbose' } &&
-      print "Creating : $config->{'output'}/tags/$index\n";
+    $config->{verbose} &&
+      print "Creating : $config->{output}/tags/$index\n";
 
-    File::Path::make_path( "$config->{'output'}/tags",
+    File::Path::make_path( "$config->{output}/tags",
                            {  verbose => 0,
                               mode    => oct("755"),
-                           } ) unless ( -d "$config->{'output'}/tags/" );
+                           } ) unless ( -d "$config->{output}/tags/" );
 
 
 
@@ -231,9 +231,9 @@ sub _outputTagCloud
     return unless ($c);
 
     $c->param( all_tags => $tags ) if ($tags);
-    $c->param( top => $config->{ 'top' } );
+    $c->param( top => $config->{top} );
 
-    open( my $handle, ">:encoding(UTF-8)", "$config->{'output'}/tags/$index" )
+    open( my $handle, ">:encoding(UTF-8)", "$config->{output}/tags/$index" )
       or
       die "Failed to open";
     print $handle $c->output();

--- a/lib/Chronicle/Plugin/Markdown.pm
+++ b/lib/Chronicle/Plugin/Markdown.pm
@@ -54,8 +54,8 @@ sub on_insert
     #
     #  The post data and input format
     #
-    my $data   = $args{ 'data' };
-    my $format = $data->{ 'format' };
+    my $data   = $args{data};
+    my $format = $data->{format};
 
     if ( $format && ( $format =~ /^markdown$/i ) )
     {

--- a/lib/Chronicle/Plugin/MultiMarkdown.pm
+++ b/lib/Chronicle/Plugin/MultiMarkdown.pm
@@ -54,8 +54,8 @@ sub on_insert
     #
     #  The post data and input format
     #
-    my $data   = $args{ 'data' };
-    my $format = $data->{ 'format' };
+    my $data   = $args{data};
+    my $format = $data->{format};
 
     if ( $format && ( $format =~ /^multimarkdown$/i ) )
     {

--- a/lib/Chronicle/Plugin/PostBuild.pm
+++ b/lib/Chronicle/Plugin/PostBuild.pm
@@ -56,14 +56,14 @@ sub on_generate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
-    return unless ( $config->{ 'post-build' } );
+    return unless ( $config->{'post-build'} );
 
-    foreach my $cmd ( @{ $config->{ 'post-build' } } )
+    foreach my $cmd ( @{ $config->{'post-build'} } )
     {
-        $config->{ 'verbose' } && print "PostBuild($cmd)\n";
+        $config->{verbose} && print "PostBuild($cmd)\n";
         system($cmd );
     }
 }

--- a/lib/Chronicle/Plugin/PostSpooler.pm
+++ b/lib/Chronicle/Plugin/PostSpooler.pm
@@ -68,20 +68,20 @@ sub on_insert
 {
     my ( $self, %args ) = (@_);
 
-    my $config = $args{ 'config' };
-    my $data   = $args{ 'data' };
+    my $config = $args{config};
+    my $data   = $args{data};
 
     #
     #  If there is no Publish header then return immediately.
     #
-    return $data unless ( $data->{ 'publish' } );
+    return $data unless ( $data->{publish} );
 
     #
     #  Now we need to see if the post is in the future or not.
     #
     #  Parse the publish-date into seconds and get the current time.
     #
-    my $seconds = str2time( $data->{ 'publish' } );
+    my $seconds = str2time( $data->{publish} );
     my $current = time();
 
     #
@@ -89,8 +89,8 @@ sub on_insert
     #
     if ( $seconds <= $current )
     {
-        $data->{ 'date' } = $data->{ 'publish' };
-        delete( $data->{ 'publish' } );
+        $data->{date} = $data->{publish};
+        delete( $data->{publish} );
         return ($data);
     }
     else

--- a/lib/Chronicle/Plugin/PreBuild.pm
+++ b/lib/Chronicle/Plugin/PreBuild.pm
@@ -55,14 +55,14 @@ sub on_initiate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
-    return unless ( $config->{ 'pre-build' } );
+    return unless ( $config->{'pre-build'} );
 
-    foreach my $cmd ( @{ $config->{ 'pre-build' } } )
+    foreach my $cmd ( @{ $config->{'pre-build'} } )
     {
-        $config->{ 'verbose' } && print "PreBuild($cmd)\n";
+        $config->{verbose} && print "PreBuild($cmd)\n";
 
         system($cmd );
     }

--- a/lib/Chronicle/Plugin/SkipDrafts.pm
+++ b/lib/Chronicle/Plugin/SkipDrafts.pm
@@ -46,17 +46,17 @@ sub on_insert
 {
     my ( $self, %args ) = (@_);
 
-    my $config = $args{ 'config' };
-    my $data   = $args{ 'data' };
+    my $config = $args{config};
+    my $data   = $args{data};
 
     #
     #  We'll return undef here, which will stop the insertion process
     #
-    if ( $data->{ 'draft' } )
+    if ( $data->{draft} )
     {
-        $config->{ 'verbose' } &&
-          $data->{ 'filename' } &&
-          print "Skipping draft: $data->{'filename'} \n";
+        $config->{verbose} &&
+          $data->{filename} &&
+          print "Skipping draft: $data->{filename} \n";
 
         ## no critic (ReturnUndef)
         return undef;

--- a/lib/Chronicle/Plugin/Snippets/AllTags.pm
+++ b/lib/Chronicle/Plugin/Snippets/AllTags.pm
@@ -60,8 +60,8 @@ sub on_initiate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
     #
     # Get the tags, and their count.
@@ -78,9 +78,9 @@ sub on_initiate
     my $tags;
 
     # Default sizing options
-    my $min  = $config->{ 'tag_cloud_size_min' }  || 5;
-    my $max  = $config->{ 'tag_cloud_size_max' }  || 60;
-    my $step = $config->{ 'tag_cloud_size_step' } || 5;
+    my $min  = $config->{tag_cloud_size_min}  || 5;
+    my $max  = $config->{tag_cloud_size_max}  || 60;
+    my $step = $config->{tag_cloud_size_step} || 5;
 
     #
     # Process the results.

--- a/lib/Chronicle/Plugin/Snippets/Archives.pm
+++ b/lib/Chronicle/Plugin/Snippets/Archives.pm
@@ -63,8 +63,8 @@ sub on_initiate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
     my %mons = ( "01" => 'January',
                  "02" => 'February',

--- a/lib/Chronicle/Plugin/Snippets/Meta.pm
+++ b/lib/Chronicle/Plugin/Snippets/Meta.pm
@@ -69,8 +69,8 @@ sub on_initiate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
 
     #
@@ -84,7 +84,7 @@ sub on_initiate
     #
     #  The chronicle build date
     #
-    my $date_fmt = $config->{ 'meta_date_format' } || '%e %b %Y';
+    my $date_fmt = $config->{meta_date_format} || '%e %b %Y';
 
     $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_date" } =
       time2str( $date_fmt, $time );
@@ -92,7 +92,7 @@ sub on_initiate
     #
     #  The chronicle build time
     #
-    my $time_fmt = $config->{ 'meta_time_format' } || '%H:%M:%S';
+    my $time_fmt = $config->{meta_time_format} || '%H:%M:%S';
 
     $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_time" } =
       time2str( $time_fmt, $time );
@@ -101,13 +101,13 @@ sub on_initiate
     #
     #  The username
     #
-    if ( $ENV{ 'USER' } )
+    if ( $ENV{USER} )
     {
 
         #
         #  Set the username
         #
-        $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_username" } = $ENV{ 'USER' };
+        $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_username" } = $ENV{USER};
 
 
         #
@@ -115,7 +115,7 @@ sub on_initiate
         #
         my ( $name,    $passwd, $uid, $gid,   $quota,
              $comment, $gcos,   $dir, $shell, $expire
-           ) = getpwnam( $ENV{ 'USER' } );
+           ) = getpwnam( $ENV{USER} );
 
         #
         #  Did we get a GCOS field?  If so strip the trailing "," and
@@ -137,7 +137,7 @@ sub on_initiate
     #  Again we start from the environment, then run `hostname` if the
     # environment isn't set.
     #
-    my $hostname = $ENV{ 'HOSTNAME' };
+    my $hostname = $ENV{HOSTNAME};
     if ( !$hostname )
     {
 

--- a/lib/Chronicle/Plugin/Snippets/RecentPosts.pm
+++ b/lib/Chronicle/Plugin/Snippets/RecentPosts.pm
@@ -77,13 +77,13 @@ sub on_initiate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
     #
     #  The number of posts to include.
     #
-    my $count = $config->{ 'recent-post-count' } || 10;
+    my $count = $config->{'recent-post-count'} || 10;
 
     my $recent =
       $dbh->prepare("SELECT id FROM blog ORDER BY date DESC LIMIT 0,$count") or
@@ -103,14 +103,14 @@ sub on_initiate
                                        config => $config
                                      );
 
-        my $x = $data->{ 'posted' };
+        my $x = $data->{posted};
         my $date = time2str( "%e %B %Y", $x );
 
         push( @$entries,
               {  date  => $date,
-                 title => $data->{ 'title' },
-                 link  => $data->{ 'link' },
-                 tags  => $data->{ 'tags' },
+                 title => $data->{title},
+                 link  => $data->{link},
+                 tags  => $data->{tags},
               } );
     }
     $recent->finish();

--- a/lib/Chronicle/Plugin/Snippets/RecentTags.pm
+++ b/lib/Chronicle/Plugin/Snippets/RecentTags.pm
@@ -63,13 +63,13 @@ sub on_initiate
 {
     my ( $self, %args ) = (@_);
 
-    my $dbh    = $args{ 'dbh' };
-    my $config = $args{ 'config' };
+    my $dbh    = $args{dbh};
+    my $config = $args{config};
 
     #
     #  The number of tags to include.
     #
-    my $count = $config->{ 'recent-tag-count' } || 10;
+    my $count = $config->{'recent-tag-count'} || 10;
 
     my $recent = $dbh->prepare(
         "SELECT a.name FROM tags AS a JOIN blog AS b WHERE ( b.id = a.blog_id  ) ORDER BY b.date DESC LIMIT $count"

--- a/lib/Chronicle/Plugin/Textile.pm
+++ b/lib/Chronicle/Plugin/Textile.pm
@@ -55,8 +55,8 @@ sub on_insert
     #
     #  The post data and input-format
     #
-    my $data   = $args{ 'data' };
-    my $format = $data->{ 'format' };
+    my $data   = $args{data};
+    my $format = $data->{format};
 
     if ( $format && ( $format =~ /^textile$/i ) )
     {

--- a/lib/Chronicle/Plugin/Tidy.pm
+++ b/lib/Chronicle/Plugin/Tidy.pm
@@ -59,9 +59,9 @@ sub on_insert
 {
     my ( $self, %args ) = (@_);
 
-    my $conf = $args{ 'config' };
-    my $data = $args{ 'data' };
-    my $html = $data->{ 'body' };
+    my $conf = $args{config};
+    my $data = $args{data};
+    my $html = $data->{body};
 
     #
     #  Load the HTML::TreeBuilder module, if present.
@@ -110,7 +110,7 @@ sub on_insert
     #
     #  Update the body and return the updated post.
     #
-    $data->{ 'body' } = $txt;
+    $data->{body} = $txt;
     return ($data);
 }
 

--- a/lib/Chronicle/Plugin/YouTube.pm
+++ b/lib/Chronicle/Plugin/YouTube.pm
@@ -66,11 +66,11 @@ sub on_insert
 {
     my ( $self, %args ) = (@_);
 
-    my $conf = $args{ 'config' };
-    my $data = $args{ 'data' };
+    my $conf = $args{config};
+    my $data = $args{data};
 
     # get the body
-    my $old_body = $data->{ 'body' };
+    my $old_body = $data->{body};
     my $new_body = "";
 
     my $updated = 0;
@@ -98,15 +98,15 @@ EOF
 
     if ($updated)
     {
-        $data->{ 'body' } = $new_body;
+        $data->{body} = $new_body;
 
-        if ( $data->{ 'tags' } )
+        if ( $data->{tags} )
         {
-            $data->{ 'tags' } .= ",youtube";
+            $data->{tags} .= ",youtube";
         }
         else
         {
-            $data->{ 'tags' } .= "youtube";
+            $data->{tags} .= "youtube";
         }
     }
 


### PR DESCRIPTION
I ran into a problem when I posted a blog entry with a title in Lao script:
http://blog.towiski.de/____.html
As you can see from the URL already, all non-ASCII characters simply get replaced by underscores, which will screw up once you have a second page with a title of equal length in any other non-ASCII script.

A temporary safety net against chronicle simply overwriting one article with the other is to create a unique index on the blog table's title column, so it will just fail with a cryptic error (it would be useful to dump the attempted query and error code if any SQL fails, too). Of course it would be preferable to have this Just Work[tm] but I'm not sure yet how to do it. I wrote some code to keep `$entry->{link}` in URL-encoded form using `URL::Encode` (without stripping on-ASCII characters first) and then to decode it again for actual file name creation, but this still doesn't work for non-Latin scripts, probably everything but ISO-Latin-1.

The important bit is the second commit, you may not like the first one though ;)