### PR TITLE
Bugfix for the inplace plugin

### DIFF
--- a/lib/Chronicle/Plugin/InPlacePosts.pm
+++ b/lib/Chronicle/Plugin/InPlacePosts.pm
@@ -73,9 +73,9 @@ sub on_insert
     if ( $config->{ 'entry_inplace' } )
     {
         $config->{ 'verbose' }  &&
-          print "Changing Link to stay in place: $data->{'filename'} \n";
+          print "Changing Link to stay in place: $data->{'file'} \n";
 
-        my $inplacelink = $data->{ 'filename' };
+        my $inplacelink = $data->{ 'file' };
 
         # strip off the source dir with the first '/'
         # this will be added back later

--- a/t/test-in-place-post.t
+++ b/t/test-in-place-post.t
@@ -20,7 +20,7 @@ $config{ 'input' } = "./blog";
 
 $data{ 'body' }     = "<p>It is true</p>";
 $data{ 'date' }     = "10th March 1976";
-$data{ 'filename' } = "./blog/2015/June/13/cake.post";
+$data{ 'file' } = "./blog/2015/June/13/cake.post";
 $data{ 'link' }     = "I_like_cake.html";
 $data{ 'title' }    = "I like cake";
 
@@ -83,7 +83,7 @@ $out =
 
 ok( $out, "Returned something." );
 is( ref($out), "HASH", "Which was a hash" );
-foreach my $key (qw(body date filename title))
+foreach my $key (qw(body date file title))
 {
     is( $data{ $key }, $out->{ $key }, "The field is unchanged: $key" );
 }


### PR DESCRIPTION
The Plugin was using `$data->{ 'filename' }` instead of the correct `$data->{ 'file' }`.

The test has been updated as well.