### PR TITLE
Fix instal deps

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,7 @@ my %WriteMakefileArgs = (
         'File::Basename'             => 0,
         'File::Find'                 => 0,
         'File::Path'                 => 0,
+        'File::ShareDir'             => 0,
         'Getopt::Long'               => 0,
         'HTML::Template'             => 0,
         'Module::Pluggable::Ordered' => 0,

--- a/lib/Chronicle/Plugin/TruncatedBody.pm
+++ b/lib/Chronicle/Plugin/TruncatedBody.pm
@@ -24,7 +24,6 @@ package Chronicle::Plugin::TruncatedBody;
 use strict;
 use warnings;
 
-use Data::Dumper;
 our $VERSION = "5.0.9";
 
 


### PR DESCRIPTION
Updated the Makefile.PL to include a missing dependency found in the `bin/chronicle`.

Also removed `Data::Dumper` from the trunctaedbody plugin 