### PR TITLE
UTF-8 filenames

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -31,6 +31,7 @@ lib/Chronicle/Plugin/Textile.pm
 lib/Chronicle/Plugin/Tidy.pm
 lib/Chronicle/Plugin/TruncatedBody.pm
 lib/Chronicle/Plugin/YouTube.pm
+lib/Chronicle/URI.pm
 LICENSE
 Makefile.PL
 MANIFEST

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,6 +39,8 @@ my %WriteMakefileArgs = (
         'Text::Markdown'      => 0,
         'Text::MultiMarkdown' => 0,
         'Text::Textile'       => 0,
+        'Unicode::Normalize'  => 0,
+        'URI'                 => 0,
     },
 
     TEST_REQUIRES => {

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -669,11 +669,7 @@ sub insertPost
     #
     #  Remove everything that's neither space nor alphanumeric
     #
-
-    #
-    #  Remove non-alphanumeric characters.
-    #
-    $meta{ 'link' } =~ s/[^a-z0-9]/_/gi;
+    $meta{ 'link' } =~ s/[^[:alnum:] ]/_/gi;
 
     #
     #  Add the suffix for the page

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -35,6 +35,9 @@ chronicle - A static blog-compiler.
    --blog-subtitle Set the title of the blog.
    --blog-title    Set the title of the blog.
    --force         Always regenerate pages.
+   --unicode=<yes|no|mac>
+                   Allow non-ASCII characters in file names. Default is
+                   `no'. Use `mac' if serving files off an HFS+ volume.
 
   Help Options:
 
@@ -309,7 +312,8 @@ Steve Kemp <steve@steve.org.uk>
 
 use strict;
 use warnings;
-
+use open ':std' => ':locale';
+use open IO => ':encoding(UTF-8)';
 
 package Chronicle;
 use Module::Pluggable::Ordered require => 1, inner => 0;
@@ -328,9 +332,8 @@ use Getopt::Long;
 use HTML::Template;
 use Pod::Usage;
 
-
+use Chronicle::URI;
 use Chronicle::Config::Reader;
-
 
 #
 #  Default options - These may be overridden by the command-line
@@ -352,6 +355,7 @@ $CONFIG{ 'entry-count' }  = 10;
 $CONFIG{ 'rss-count' }    = 10;
 $CONFIG{ 'theme-dir' }    = File::ShareDir::dist_dir('App-Chronicle');
 $CONFIG{ 'theme' }        = "default";
+$CONFIG{ 'unicode' }      = "no";
 $CONFIG{ 'verbose' }      = 0;
 $CONFIG{ 'top' }          = "/";
 $CONFIG{ 'exclude-plugins' } =
@@ -402,7 +406,10 @@ parseCommandLine();
 $cnf->parseFile( \%CONFIG, $CONFIG{ 'config' } )
   if ( defined $CONFIG{ 'config' } );
 
-
+#
+# Switch on Mac quirks for Unicode file names if required
+#
+Chronicle::URI::i_use_hfs if $CONFIG{ 'unicode' } eq 'mac';
 
 #
 # Get the database handle, creating the database on-disk if necessary.
@@ -664,23 +671,16 @@ sub insertPost
     #
     #  Generate the link from the title of the post.
     #
-    $meta{ 'link' } = $meta{ 'title' };
-
-    #
-    #  Remove everything that's neither space nor alphanumeric
-    #
-    $meta{ 'link' } =~ s/[^[:alnum:] ]/_/gi;
-
-    #
-    #  Add the suffix for the page
-    #
-    my $suffix = $CONFIG{ 'entry_suffix' } || ".html";
-    $meta{ 'link' } .= $suffix;
-
-    #
-    #  Lower-case
-    #
-    $meta{ 'link' } = lc( $meta{ 'link' } );
+    my $suffix = $CONFIG{ 'entry_suffix' } // ".html";
+    my $link = $meta{ 'title' };
+    if($CONFIG{'unicode' } eq 'no') {
+        # Unicode off, only use 7-bit alphanumerics from titles
+        $link =~ s/[^a-zA-Z0-9]/_/gi;
+    } else {
+        # Allow everything alphanumeric in any Unicode block
+        $link =~ s/[^[:alnum:]]/_/gi;
+    }
+    $meta{ 'link' } = Chronicle::URI->new( $link . $suffix );
 
     #
     #  Let any plugins have access to the filename.
@@ -951,20 +951,13 @@ sub getBlog
     #
     #  Get the tags, if any
     #
-    my $tags =
-      $dbh->prepare("SELECT name FROM tags WHERE blog_id=? ORDER by name ASC")
-      or
-      die "Failed to prepare";
-    my $name;
-    $tags->execute($id) or die "Failed to execute: " . $dbh->errstr();
-    $tags->bind_columns( undef, \$name );
-    while ( $tags->fetch() )
-    {
-        my $x = $data->{ 'tags' };
-        push( @$x, { tag => $name } );
-        $data->{ 'tags' } = $x;
-    }
-    $tags->finish();
+    my $tags = $dbh->selectall_arrayref(
+        "SELECT name FROM tags WHERE blog_id=? ORDER by name ASC"
+    ) or die "Failed in selectall_arrayref(): ". $dbh->errstr();
+    $data->{ 'tags' } = [ map { { tag => $_->[0] } } @$tags ];
+
+    # Create an URI object for the link
+    $data->{ 'link' } = Chronicle::URI->new($data->{ 'link' });
 
     #
     #  Generate the date/time from mtime;
@@ -1385,6 +1378,7 @@ sub parseCommandLine
             "author=s",       \$CONFIG{ 'author' },
             "comment-days=s", \$CONFIG{ 'comment-days' },
             "force",          \$CONFIG{ 'force' },
+            "unicode=s",      \$CONFIG{ 'unicode' },
 
             # plugins
             "list-plugins",      \$CONFIG{ 'list-plugins' },
@@ -1475,6 +1469,13 @@ sub parseCommandLine
             }
         }
         exit 0;
+    }
+
+    # Show an error if 'unicode' is not an allowed value
+    $CONFIG{ 'unicode' } = lc $CONFIG{ 'unicode' };
+    unless(grep { $_ eq $CONFIG{ 'unicode' } } qw/ no yes mac /) {
+        print STDERR "--unicode must be one of `yes', `no' or `mac'";
+        exit 1;
     }
 }
 

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -667,9 +667,8 @@ sub insertPost
     $meta{ 'link' } = $meta{ 'title' };
 
     #
-    #  Remove the extension - regardless of what that might be.
+    #  Remove everything that's neither space nor alphanumeric
     #
-    $meta{ 'link' } =~ s/\.[^.]+$//;
 
     #
     #  Remove non-alphanumeric characters.

--- a/lib/Chronicle/Plugin/Archived.pm
+++ b/lib/Chronicle/Plugin/Archived.pm
@@ -37,7 +37,6 @@ our $VERSION = "5.1.2";
 use Date::Format;
 use Date::Parse;
 
-
 =head2 on_insert
 
 The C<on_insert> method is automatically invoked when a new blog post
@@ -75,7 +74,7 @@ sub on_insert
     #
     #  And prepend that to the link.
     #
-    $data->{ 'link' } = $date . $data->{ 'link' };
+    $data->{ 'link' }->path_prepend($date);
 
     return ($data);
 }

--- a/lib/Chronicle/Plugin/Generate/Pages.pm
+++ b/lib/Chronicle/Plugin/Generate/Pages.pm
@@ -112,8 +112,8 @@ sub on_generate
         #
         #  Work out where it will be written to
         #
-        my $out = $config->{ 'output' } . "/" . $entry->{ 'link' };
-
+        my $out = $config->{ 'output' } . "/" . $entry->{ 'link' }->unescaped;
+        print STDERR "Writing `$out'\n";
         #
         #  We skip posts that are already present:
         #
@@ -153,7 +153,7 @@ sub on_generate
 
 
         $config->{ 'verbose' } &&
-          print "Creating : $config->{'output'}/$entry->{'link'}\n";
+          print "Creating : $out\n";
 
         my $c = Chronicle::load_template( $entry->{ 'template' } );
         return unless ($c);
@@ -199,9 +199,8 @@ sub on_generate
                                    } );
         }
 
-        open( my $handle, ">:encoding(UTF-8)",
-              $config->{ 'output' } . "/" . $entry->{ 'link' } ) or
-          die "Failed to open";
+        open( my $handle, ">:encoding(UTF-8)", $out)
+            or die "Failed to open `$out' for writing: $!";
         print $handle $c->output();
         close($handle);
 

--- a/lib/Chronicle/Plugin/Generate/Pages.pm
+++ b/lib/Chronicle/Plugin/Generate/Pages.pm
@@ -113,7 +113,6 @@ sub on_generate
         #  Work out where it will be written to
         #
         my $out = $config->{ 'output' } . "/" . $entry->{ 'link' }->unescaped;
-        print STDERR "Writing `$out'\n";
         #
         #  We skip posts that are already present:
         #

--- a/lib/Chronicle/Plugin/InPlacePosts.pm
+++ b/lib/Chronicle/Plugin/InPlacePosts.pm
@@ -5,7 +5,6 @@ Chronicle::Plugin::InPlacePosts - maintains the input directory structure.
 
 =head1 DESCRIPTION
 
-This plugin is designed to allow blog entries to be filtered via
 This plugin is designed to allow blog entries remain in the same
 directory structure as the input folder by adding the config
 C<entry_inplace>.
@@ -73,7 +72,7 @@ sub on_insert
     if ( $config->{ 'entry_inplace' } )
     {
         $config->{ 'verbose' } &&
-          print "Changing Link to stay in place: $data->{'file'} \n";
+          print "Changing Link to stay in place: $data->{'file'}\n";
 
         my $inplacelink = $data->{ 'file' };
 
@@ -92,7 +91,7 @@ sub on_insert
         # we need to add a '/' between it ans the file name
         $inplacelink .= '/' if ( $inplacelink !~ /^\s*$/ );
 
-        $data->{ 'link' } = $inplacelink . $data->{ 'link' };
+        $data->{ 'link' }->path_prepend($inplacelink);
     }
 
     return ($data);

--- a/lib/Chronicle/Plugin/TruncatedBody.pm
+++ b/lib/Chronicle/Plugin/TruncatedBody.pm
@@ -66,7 +66,7 @@ sub on_insert
     #  Get the body of the post, and the link
     #
     my $body = $data->{ 'body' };
-    my $link = $data->{ 'link' } || '';
+    my $link = defined $data->{ 'link' } ? $data->{ 'link' }->as_string : '';
 
     #
     #  The link needs to be qualified.

--- a/lib/Chronicle/URI.pm
+++ b/lib/Chronicle/URI.pm
@@ -1,0 +1,112 @@
+package Chronicle::URI;
+use strict;
+use warnings;
+use URI;
+use Unicode::Normalize 'normalize';
+
+use parent 'URI';
+
+our $NORMALFORM = 'C';
+
+=head1 NAME
+
+Chronicle::URI - A URI subclass that simplifies handling of HTTP URIs
+
+=head1 DESCRIPTION
+
+It is advantageous to handle URIs as objects for easier Unicode handling,
+canonicalization etc.
+
+We ony need HTTP URIs here so we can save some boilerplate by subclassing URI,
+but some extra methods for unescaping and prepending/appending also come in
+handy.
+
+This class will convert any string arguments passed to it to Unicode NFC form
+
+=head1 METHODS
+
+=head2 new
+
+The constructor takes only a single argument that will be assumed to be an http
+URI, or in our case usually a path fragment thereof.
+
+=cut
+
+sub new {
+    my ($class, $path) = @_;
+    my $self = $class->SUPER::new( normalize($NORMALFORM, $path), 'http' );
+    return bless $self, $class;
+}
+
+=head2 unescaped
+
+Return the URI or framgemt completely unescaped. That is, the result of
+URI::as_iri with additionally all the ASCII characters unescaped. This method
+is supposed to generate a filename from an URI.
+
+=cut
+
+sub unescaped {
+    my ($self) = @_;
+    my $iri = $self->as_iri;
+    # Unescape all the ASCII left escaped by as_iri();
+    $iri =~ s/%([[:xdigit:]]{2})/chr(hex $1)/eg;
+    return $iri;
+}
+
+
+=head2 path_append
+
+Append its string argument to the path part of the URI.
+
+=cut
+
+sub path_append {
+    my ($self, $s) = @_;
+    return $self->path( $self->path . normalize($NORMALFORM, $s) ); 
+}
+
+=head2 path_prepend
+
+Prepend its string argument to the path part of the URI.
+
+=cut
+
+sub path_prepend {
+    my ($self, $s) = @_;
+    return $self->path( normalize($NORMALFORM, $s) . $self->path ); 
+}
+
+=head2 i_use_hfs
+
+This is a class method that must be called prior to creating any objects that
+you want to render in a way that will be compatible with serving them from an
+HFS+ file system. HFS+ converts non-ASCII characters in file names to Unicode
+NFD form fo URIs have to be composed differently or the corresponding files
+won't be found later.
+
+=cut
+
+sub i_use_hfs {
+    our $NORMALFORM = 'D';
+}
+
+=head1 LICENSE
+
+This module is free software; you can redistribute it and/or modify it
+under the terms of either:
+
+a) the GNU General Public License as published by the Free Software
+Foundation; either version 2, or (at your option) any later version,
+or
+
+b) the Perl "Artistic License".
+
+=head1 AUTHOR
+
+Matthias Bethke <matthias@towiski.de>
+
+=cut
+
+1;
+

--- a/t/test-archive-links.t
+++ b/t/test-archive-links.t
@@ -8,8 +8,10 @@ use Test::More tests => 9;
 #
 #  Load the module.
 #
-BEGIN {use_ok('Chronicle::Plugin::Archived');}
-require_ok('Chronicle::Plugin::Archived');
+BEGIN {
+    use_ok('Chronicle::Plugin::Archived');
+    use_ok('Chronicle::URI');
+}
 
 
 #
@@ -19,7 +21,7 @@ my %data;
 my $link = "/some_blog_post.html";
 
 $data{ 'body' } = "This is **bold**";
-$data{ 'link' } = $link;
+$data{ 'link' } = Chronicle::URI->new($link);
 $data{ 'date' } = scalar( localtime() );
 
 
@@ -42,14 +44,14 @@ foreach my $key (qw! body date title !)
 #
 #  But the link should have done
 #
-isnt( $out->{ 'link' }, $link, "The link is updated" );
+isnt( $out->{ 'link' }->as_string, $link, "The link is updated" );
 
 
 #
 #  We should expect NNNN/MM/$title
 #
-my $YEAR = substr( $data{ 'link' }, 0, 4 );
-my $MON  = substr( $data{ 'link' }, 5, 2 );
+my $YEAR = substr( $data{ 'link' }->as_string, 0, 4 );
+my $MON  = substr( $data{ 'link' }->as_string, 5, 2 );
 
 #
 #  Test they're numeric.
@@ -72,5 +74,5 @@ $mon  += 1;
 #
 $mon = sprintf( "%02d", $mon );
 
-is( $out->{ 'link' },
-    "$year/$mon/$link", "We got the link we expected: $out->{'link'}" );
+is( $out->{ 'link' }->as_string,
+    "$year/$mon/$link", "We got the link we expected: " . $out->{'link'}->as_string );


### PR DESCRIPTION
This patch introduces a new commandline option, `--unicode`. Set to `no` by default, the behavior is the same as before, i.e. to create file names from post titles with all non-ASCII-alphanumerics replaced by underscores. `--unicode=yes` makes sure titles are in UTF-8 NFC (fully composed normal form) and keeps all alphanumeric characters in any Unicode block, i.e. file names can then contain umlauts, accented characters, greek or whatever other script. `--unicode=mac` is the same except that it uses NFD (decomposed normal form) so links will be correct if files are served off an HFS+ volume that converts all names to NFD internally.

To do this, I have added a dependency on `Unicode::Normalize` (core module) and the ubiquitous `URI`. Using `URI` just for (un)escaping links wouldn't strictly be necessary but it makes things a little easier and I hope to use it to solve the problem of relative links in RSS later.

So far, this has worked fine for compiling [blog.towiski.de](http://blog.towiski.de) (see e.g. "[Engrish ສາມ](http://blog.towiski.de/Engrish_%E0%BA%AA%E0%BA%B2%E0%BA%A1.html)") and it passes all the old tests plus a few I added, but there may of course be bugs. Some browsers may have different ideas about the normalization to use when you enter non-ascii URIs by hand (which is a general problem of UTF-8 URIs) , and the Mac mode is completely untested and only based on stuff I came across when researching how to do this correctly.