### PR TITLE
Localized post dates

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -37,6 +37,7 @@ lib/Chronicle/Template/HTMLTemplate.pm
 lib/Chronicle/Template/Xslate.pm
 lib/Chronicle/Template/XslateTT.pm
 lib/Chronicle/URI.pm
+lib/Chronicle/Utils.pm
 LICENSE
 Makefile.PL
 MANIFEST

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -287,14 +287,15 @@ new data available to all the templates.
 This is how the global tag-cloud, recent posts, and similar data is able
 to be included in the sidebar in the default template.
 
-=item How do I generate non-English month names?
+=item How do I generate non-English dates?
 
-Chronicle uses the L<Date::Language> module for outputing month-names
-in the archive index.
+Chronicle uses the L<Date::Language> module for generating localized dates.
+For each of the variables "date", "time" and "date_short" there exists a
+corresponding variable with the suffix "_loc" ("date_loc" etc.) that
+contains the localized version.
 
-By default "English" is used, but if you set the environmental variable
-C<MONTHS> then the contents will be used.  For example you might enjoy
-the Finnish month-names, which can be achieved via:
+For historical reasons, the language is configured via the environment variable
+C<$MONTHS>. For example, to get Finnish dates, you could use:
 
 =for example begin
 
@@ -352,6 +353,7 @@ use DBI;
 use Date::Format;
 use Date::Parse;
 use Digest::MD5 qw(md5_hex);
+use Encode qw/ decode /;
 use File::Basename;
 use File::Find;
 use File::Path;
@@ -1022,76 +1024,21 @@ sub getBlog
     #
     #  If the date is not set then we use the mtime for both date & time.
     #
-    my $time;
-    my $posted = $data->{ 'posted' } = $data->{ 'date' };
-    if ( $data->{ 'date' } )
-    {
-        $time = $data->{ 'date' };
-    }
-    else
-    {
-        $time = $posted = $data->{ 'mtime' };
-    }
+    my $posted = ($data->{ 'posted' } = $data->{ 'date' }) || $data->{ 'mtime' } ;
+    my $time = $posted;
 
 
     ##
-    ##  Get the format-strings to use for time-formatting.
+    ##  Format dates and times
     ##
-    my $time_fmt = "%H:%M:%S";
-    if ($config)
-    {
-        $time_fmt = $config->{ "time_format" } || "%H:%M:%S";
-    }
-    $time_fmt = undef if ( $time_fmt !~ /%/ );
-
-
-    ##
-    ##  Ditto for the date-string.
-    ##
-    my $date_fmt = "%a, %e %b %Y";
-    if ($config)
-    {
-        $date_fmt = $config->{ "date_format" } || "%a, %e %b %Y";
-    }
-    $date_fmt = undef if ( $date_fmt !~ /%/ );
-
-
-    #
-    #  The date of the entry - if we have a date-format that contains
-    # at least one % character.
-    #
-    if ( $date_fmt && length($date_fmt) )
-    {
-        $data->{ 'date' } = time2str( $date_fmt, $time );
-    }
-
-
-    #
-    #  The time of the entry - if we have a time-format that contains
-    # at least one % character.
-    #
-    if ( $time_fmt && length($time_fmt) )
-    {
-
-        #
-        #  The time from the import-date.
-        #
-        $data->{ 'time' } = time2str( $time_fmt, $time );
-
-        #
-        #  If that failed then from the modification-time.
-        #
-        if ( $data->{ 'time' } =~ /00:00:00/ )
-        {
-            $data->{ 'time' } = time2str( $time_fmt, $data->{ 'mtime' } );
-        }
-    }
+    @$data{qw/ time time_loc /} = format_datetime($config, 'time_format', '%X', $time);
+    @$data{qw/ date date_loc /} = format_datetime($config, 'date_format', '%a, %e %b %Y', $time);
+    @$data{qw/ date_short date_short_loc /} = format_datetime($config, 'short_date_format', '%e %B %Y', $time);
 
     #
     #  For the RSS-Feed
     #
-    $data->{ 'iso_8601' } = time2str( '%Y-%m-%dT', $time );
-    $data->{ 'iso_8601' } .= $data->{ 'time' } . "-00:00";
+    $data->{ 'iso_8601' } = time2str( '%Y-%m-%dT%T%z', $time );
 
 
     #
@@ -1133,6 +1080,31 @@ sub getBlog
     return ($data);
 }
 
+
+=begin doc
+
+Format a date or time value to a string. Uses a config setting passed in $config_var
+or a default format in $date_fmt to generate both an English and a localized version.
+An empty list is returned if the format string doesn't contain a % character.
+
+=end doc
+
+=cut
+
+sub format_datetime {
+    my ($config, $config_var, $format, $time) = @_;
+
+    # If the config overrides the default $date_fmt, use it
+    $format = $config->{$config_var} if $config and $config->{$config_var};
+
+    return unless $format =~ /%/;
+
+    return
+    time2str( $format, $time ),
+    decode('ISO-8859-1',
+        Date::Language->new( $ENV{ 'MONTHS' } // "English" )->time2str( $format, $time )
+    );
+}
 
 
 =begin doc

--- a/bin/chronicle
+++ b/bin/chronicle
@@ -353,7 +353,6 @@ use DBI;
 use Date::Format;
 use Date::Parse;
 use Digest::MD5 qw(md5_hex);
-use Encode qw/ decode /;
 use File::Basename;
 use File::Find;
 use File::Path;
@@ -362,6 +361,7 @@ use Getopt::Long;
 use HTML::Element;
 use Pod::Usage;
 
+use Chronicle::Utils qw/ format_datetime /;
 use Chronicle::URI;
 use Chronicle::Config::Reader;
 use Chronicle::Template;
@@ -1080,31 +1080,6 @@ sub getBlog
     return ($data);
 }
 
-
-=begin doc
-
-Format a date or time value to a string. Uses a config setting passed in $config_var
-or a default format in $date_fmt to generate both an English and a localized version.
-An empty list is returned if the format string doesn't contain a % character.
-
-=end doc
-
-=cut
-
-sub format_datetime {
-    my ($config, $config_var, $format, $time) = @_;
-
-    # If the config overrides the default $date_fmt, use it
-    $format = $config->{$config_var} if $config and $config->{$config_var};
-
-    return unless $format =~ /%/;
-
-    return
-    time2str( $format, $time ),
-    decode('ISO-8859-1',
-        Date::Language->new( $ENV{ 'MONTHS' } // "English" )->time2str( $format, $time )
-    );
-}
 
 
 =begin doc

--- a/etc/config.sample
+++ b/etc/config.sample
@@ -190,7 +190,7 @@ exclude-plugins = Chronicle::Plugin::Archived,Chronicle::Plugin::Verbose
 #  Here we define the date/time formats which are used.
 #
 meta_date_format = %e %b %Y
-meta_time_format = %H:%M:%S
+meta_time_format = %X
 
 
 #
@@ -200,7 +200,8 @@ meta_time_format = %H:%M:%S
 #  These may be influenced.
 #
 date_format = %a, %e %b %Y
-time_format = %H:%M:%S
+time_format = %X
+short_date_format = %e %b %Y
 
 #
 #  If you wish to disable either for some reason then just set to a value

--- a/lib/Chronicle/Plugin/Snippets/Meta.pm
+++ b/lib/Chronicle/Plugin/Snippets/Meta.pm
@@ -50,6 +50,7 @@ use warnings;
 use Date::Format;
 use Sys::Hostname;
 
+use Chronicle::Utils qw/ format_datetime /;
 
 our $VERSION = "5.1.5";
 
@@ -87,7 +88,7 @@ sub on_initiate
     (
         $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_date" },
         $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_date_loc" }
-    ) = Chronicle::format_datetime($config, 'meta_date_format', '%e %b %Y', $time);
+    ) = format_datetime($config, 'meta_date_format', '%e %b %Y', $time);
 
     #
     #  The chronicle build time
@@ -95,7 +96,7 @@ sub on_initiate
     (
         $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_time" },
         $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_time_loc" }
-    ) = Chronicle::format_datetime($config, 'meta_time_format', '%X', $time);
+    ) = format_datetime($config, 'meta_time_format', '%X', $time);
 
     #
     #  The username

--- a/lib/Chronicle/Plugin/Snippets/Meta.pm
+++ b/lib/Chronicle/Plugin/Snippets/Meta.pm
@@ -10,7 +10,7 @@ which includes:
 
 =over 8
 
-=item The ate the blog was (re)built.
+=item The date the blog was (re)built.
 
 =item The time the blog was (re)built.
 
@@ -84,19 +84,18 @@ sub on_initiate
     #
     #  The chronicle build date
     #
-    my $date_fmt = $config->{ 'meta_date_format' } || '%e %b %Y';
-
-    $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_date" } =
-      time2str( $date_fmt, $time );
+    (
+        $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_date" },
+        $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_date_loc" }
+    ) = Chronicle::format_datetime($config, 'meta_date_format', '%e %b %Y', $time);
 
     #
     #  The chronicle build time
     #
-    my $time_fmt = $config->{ 'meta_time_format' } || '%H:%M:%S';
-
-    $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_time" } =
-      time2str( $time_fmt, $time );
-
+    (
+        $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_time" },
+        $Chronicle::GLOBAL_TEMPLATE_VARS{ "build_time_loc" }
+    ) = Chronicle::format_datetime($config, 'meta_time_format', '%X', $time);
 
     #
     #  The username

--- a/lib/Chronicle/Plugin/Snippets/RecentPosts.pm
+++ b/lib/Chronicle/Plugin/Snippets/RecentPosts.pm
@@ -102,16 +102,8 @@ sub on_initiate
                                        id     => $id,
                                        config => $config
                                      );
-
-        my $x = $data->{ 'posted' };
-        my $date = time2str( "%e %B %Y", $x );
-
-        push( @$entries,
-              {  date  => $date,
-                 title => $data->{ 'title' },
-                 link  => $data->{ 'link' },
-                 tags  => $data->{ 'tags' },
-              } );
+        delete @$data{qw/ body truncatedbody /};    # get rid of heavy fields
+        push @$entries, $data;
     }
     $recent->finish();
 
@@ -119,7 +111,7 @@ sub on_initiate
     #
     #  Now we have the structure.
     #
-    $Chronicle::GLOBAL_TEMPLATE_VARS{ "recent_posts" } = $entries if ($entries);
+    $Chronicle::GLOBAL_TEMPLATE_VARS{ "recent_posts" } = $entries if $entries;
 }
 
 

--- a/lib/Chronicle/Utils.pm
+++ b/lib/Chronicle/Utils.pm
@@ -1,0 +1,46 @@
+package Chronicle::Utils;
+use strict;
+use warnings;
+use Encode qw/ decode /;
+use Date::Format;
+use Date::Language;
+use parent 'Exporter';
+
+our @EXPORT_OK = qw/ format_datetime /;
+
+=head1 NAME
+
+Chronicle::Utils - some utility functions needed here and there
+
+=head1 DESCRIPTION
+
+So far, this only contains the date/time localization function to avoid too
+much ugly cross-namespace calling.
+
+=head1 FUNCTIONS
+
+=head2 format_datetime
+
+Format a date or time value to a string. Uses a config setting passed in $config_var
+or a default format in $date_fmt to generate both an English and a localized version.
+An empty list is returned if the format string doesn't contain a % character.
+
+=cut
+
+my $date_loc = Date::Language->new( $ENV{ 'MONTHS' } // "English" );
+
+sub format_datetime {
+    my ($config, $config_var, $format, $time) = @_;
+
+    # If the config overrides the default $date_fmt, use it
+    $format = $config->{$config_var} if $config and $config->{$config_var};
+
+    return unless $format =~ /%/;
+
+    return
+    time2str( $format, $time ),
+    decode('ISO-8859-1', $date_loc->time2str( $format, $time ));
+}
+
+1;
+

--- a/t/test-version-insertion.t
+++ b/t/test-version-insertion.t
@@ -3,19 +3,19 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 9;
 
 #
 #  Load the module.
 #
 BEGIN {use_ok('Chronicle::Plugin::Snippets::Meta');}
-require_ok('Chronicle::Plugin::Snippets::Meta');
-
 
 package Chronicle;
 
 our $VERSION              = "cake.free";
 our %GLOBAL_TEMPLATE_VARS = ();
+# This is a hack that works because the function isn't being tested anyway
+sub format_datetime {}
 
 package main;
 


### PR DESCRIPTION
Here's another itch I just scratched:

While there was some support for localized month names in the Archive plugin, others like RecentPosts still had hardcoded format strings and only provided the non-localized versions. This patch adds localized dates (short and long version) and times to the `getBlog()` function so they are available everywhere.

* Add Chronicle::Utils with currently just one function `format_datetime()` that produces both a POSIX-formatted and a localized version, using the existing though now somewhat strangely named `$MONTHS` variable)
* Add a short_date_format config option analogous to meta_date_format, so you always have `date`, `date_loc`, `date_short` and `date_short_loc` available.
* Also add a `time_loc` variable. The default format for times is `%X` now, the "preferred time representation for the current locale without the date.", so this may render differently in other locales, too.
* Provide localized time versions in `Chronicle::Plugin::Snippets::Meta`, too.
* Remove `require_ok()` from test-version-insertion.t as that is covered by the
  `use_ok()` already