### PR TITLE
Correctly handle truncated posts in all themes.

### DIFF
--- a/themes/default/archive.tmpl
+++ b/themes/default/archive.tmpl
@@ -19,7 +19,11 @@
         <!-- tmpl_var name='date' escape='html' --><!-- tmpl_if name='time' --> at <!-- tmpl_var name='time' --><!-- /tmpl_if -->
       </div>
       <div class="body">
-        <!-- tmpl_var name='body' -->
+        <!-- tmpl_if name='truncatedbody' -->
+           <!-- tmpl_var name='truncatedbody' -->
+        <!-- tmpl_else -->
+           <!-- tmpl_var name='body' -->
+        <!-- /tmpl_if -->
       </div>
       <div class="tags">
         <!-- tmpl_if name='comment_count' -->

--- a/themes/default/index.tmpl
+++ b/themes/default/index.tmpl
@@ -13,7 +13,13 @@
     <div class="entry">
       <div class="title"><a href="<!-- tmpl_var name='top' --><!-- tmpl_var name='link' escape='html' -->"><!-- tmpl_var name='title' --></a></div>
       <div class="date"><!-- tmpl_var name='date' escape='html' --><!-- tmpl_if name='time' --> at <!-- tmpl_var name='time' --><!-- /tmpl_if --></div>
-      <div class="body"><!-- tmpl_var name='body' --></div>
+      <div class="body">
+        <!-- tmpl_if name='truncatedbody' -->
+           <!-- tmpl_var name='truncatedbody' -->
+        <!-- tmpl_else -->
+           <!-- tmpl_var name='body' -->
+        <!-- /tmpl_if -->
+      </div>
       <div class="tags">
         <!-- tmpl_if name='comment_count' -->
         <span class="comments">

--- a/themes/default/tag.tmpl
+++ b/themes/default/tag.tmpl
@@ -18,7 +18,11 @@
         <!-- tmpl_var name='date' escape='html' --><!-- tmpl_if name='time' --> at <!-- tmpl_var name='time' --><!-- /tmpl_if -->
       </div>
       <div class="body">
-        <!-- tmpl_var name='body' -->
+        <!-- tmpl_if name='truncatedbody' -->
+           <!-- tmpl_var name='truncatedbody' -->
+        <!-- tmpl_else -->
+           <!-- tmpl_var name='body' -->
+        <!-- /tmpl_if -->
       </div>
       <div class="tags">
         <!-- tmpl_if name='comment_count' -->

--- a/themes/leftbar/archive.tmpl
+++ b/themes/leftbar/archive.tmpl
@@ -16,7 +16,7 @@
 <blockquote>
 <!-- tmpl_if name='entries' -->
 <!-- tmpl_loop name='entries' -->
-  <!-- tmpl_include name='inc/blog-post.inc' -->
+  <!-- tmpl_include name='inc/blog-post-truncated.inc' -->
 <!-- /tmpl_loop -->
 <!-- /tmpl_if -->
 </blockquote>

--- a/themes/leftbar/inc/blog-post-truncated.inc
+++ b/themes/leftbar/inc/blog-post-truncated.inc
@@ -1,0 +1,29 @@
+<div>
+  <h2 style="width:100%; border-bottom:1px solid silver;"><a href="<!-- tmpl_var name='top' --><!-- tmpl_var name='link' escape='html' -->" style="text-decoration:none; color:black;"><!-- tmpl_var name='title' --></a></h2>
+  <p style="text-align:right; width:100%"><!-- tmpl_var name='date' --><!-- tmpl_if name='time' --> at <!-- tmpl_var name='time' --><!-- /tmpl_if --></p>
+  <div class="entry-content">
+  <!-- tmpl_if name='truncatedbody' -->
+    <!-- tmpl_var name='truncatedbody' -->
+  <!-- tmpl_else -->
+    <!-- tmpl_var name='body' -->
+  <!-- /tmpl_if -->
+  </div>
+  <p style="text-align:right;width:100%">
+    <span class="entry-category">
+      <!-- tmpl_if name='tags' -->
+      Tags: <!-- tmpl_loop name='tags' --><a href="<!-- tmpl_var name='top' -->tags/<!-- tmpl_var name='tag' escape='html' -->"><!-- tmpl_var name='tag' escape='html' --></a><!-- tmpl_if name="__last__" -->.<!-- tmpl_else -->, <!-- /tmpl_if --><!-- /tmpl_loop -->
+      <!-- tmpl_else -->
+      No tags
+      <!-- /tmpl_if -->
+    </span>
+    <span class="meta-sep">|</span>
+    <span class="entry-comments">
+      <!-- tmpl_if name='comment_count' -->
+      <a href="<!-- tmpl_var name='top' --><!-- tmpl_var name='link' escape='html' -->"><!-- tmpl_var name='comment_count' --> comment<!-- tmpl_if name='comment_plural' -->s<!-- /tmpl_if -->.</a>
+      <!-- tmpl_else -->
+      No comments
+      <!-- /tmpl_if -->
+    </span>
+    </p>
+</div>
+<p>&nbsp;</p>

--- a/themes/leftbar/index.tmpl
+++ b/themes/leftbar/index.tmpl
@@ -15,7 +15,7 @@
  <td valign="top" width="80%" style="border-left: 1px solid grey; padding:5px">
 <!-- tmpl_if name='entries' -->
 <!-- tmpl_loop name='entries' -->
-  <!-- tmpl_include name='inc/blog-post.inc' -->
+  <!-- tmpl_include name='inc/blog-post-truncated.inc' -->
 <!-- /tmpl_loop -->
 <!-- /tmpl_if -->
 </td></tr></table>

--- a/themes/leftbar/tag.tmpl
+++ b/themes/leftbar/tag.tmpl
@@ -16,7 +16,7 @@
 <h1>Entries tagged <!-- tmpl_var name='tag' escape='html' --></h1>
 <!-- tmpl_if name='entries' -->
 <!-- tmpl_loop name='entries' -->
-  <!-- tmpl_include name='inc/blog-post.inc' -->
+  <!-- tmpl_include name='inc/blog-post-truncated.inc' -->
 <!-- /tmpl_loop -->
 <!-- tmpl_else name='entries' -->
 <p>No entries were found with the given tag.</p>


### PR DESCRIPTION
This closes #33, by makign sure that every view of a truncated
blog-post will only show that truncated view:

* The archive.
* The front-page.
* The tag-page.

The only page that will contain the complete body will be the
page-specific-page.

= Quick Checklist =

I welcome the submission of additional features, and improvements to
the codebase.  This template-file contains just a few last minute checks
to complete before you submit your pull-request:

[ ] Did you run the test-cases?
    - If you did, great!

[ ] Did you add any new modules?
    - If so please remember to make sure your name is listed as the AUTHOR.
    - Don't forget to write the documentation, at the top of the module.

[ ] Did you reformat the code?
    - There is a `.perltidyrc` file in the repository, so just run this:
        perltidy $(find . -name '*.pm')
